### PR TITLE
fix: update opencode skill path from 'skill' to 'skills'

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,7 +38,7 @@ func DefaultTargets() map[string]TargetConfig {
 		"gemini":      {Path: filepath.Join(home, ".gemini", "skills")},
 		"goose":       {Path: filepath.Join(home, ".config", "goose", "skills")},
 		"letta":       {Path: filepath.Join(home, ".letta", "skills")},
-		"opencode":    {Path: filepath.Join(home, ".config", "opencode", "skill")},
+		"opencode":    {Path: filepath.Join(home, ".config", "opencode", "skills")},
 	}
 }
 

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -140,7 +140,7 @@ func IsLikelySkillsPath(path string) bool {
 		".codex/skills",
 		".cursor/skills",
 		".gemini/antigravity/skills",
-		".config/opencode/skill",
+		".config/opencode/skills",
 	}
 
 	for _, pattern := range knownPatterns {


### PR DESCRIPTION
Opencode has unified their path from skill -> skills.
See: https://opencode.ai/docs/skills/

## Summary

- Update opencode default path from `~/.config/opencode/skill` to `~/.config/opencode/skills`
- Opencode has unified their path naming convention

Reference: https://opencode.ai/docs/skills/

## Migration for existing users

If you were using the old opencode skill path, run:

```bash
# Move skills to new location
mv ~/.config/opencode/skill ~/.config/opencode/skills

# Update skillshare target (if configured)
skillshare remove opencode
skillshare add opencode ~/.config/opencode/skills
