### PR TITLE
feat(sync): add copy mode to sync skills without symlinks

### DIFF
--- a/cmd/skillshare/status_project.go
+++ b/cmd/skillshare/status_project.go
@@ -100,7 +100,7 @@ func printProjectTargetsStatus(runtime *projectRuntime, discovered []sync.Discov
 			mode = "merge"
 		}
 
-		statusStr, detail := getTargetStatusDetail(target, runtime.sourcePath, mode)
+		statusStr, detail := getTargetStatusDetail(entry.Name, target, runtime.sourcePath, mode)
 		ui.Status(entry.Name, statusStr, detail)
 
 		if mode == "merge" {
@@ -113,6 +113,14 @@ func printProjectTargetsStatus(runtime *projectRuntime, discovered []sync.Discov
 			_, linkedCount, _ := sync.CheckStatusMerge(target.Path, runtime.sourcePath)
 			if linkedCount < expectedCount {
 				drift := expectedCount - linkedCount
+				if drift > driftTotal {
+					driftTotal = drift
+				}
+			}
+		} else if mode == "copy" {
+			expectedCount, copiedCount, err := sync.CheckStatusCopy(target.Path, runtime.sourcePath, target.Include, target.Exclude, entry.Name)
+			if err == nil && copiedCount < expectedCount {
+				drift := expectedCount - copiedCount
 				if drift > driftTotal {
 					driftTotal = drift
 				}

--- a/cmd/skillshare/sync_project.go
+++ b/cmd/skillshare/sync_project.go
@@ -63,6 +63,11 @@ func cmdSyncProject(root string, dryRun, force bool) (syncLogStats, error) {
 				ui.Error("%s: %v", name, err)
 				failedTargets++
 			}
+		} else if mode == "copy" {
+			if err := syncCopyMode(name, target, runtime.sourcePath, dryRun, force); err != nil {
+				ui.Error("%s: %v", name, err)
+				failedTargets++
+			}
 		} else {
 			if err := syncMergeMode(name, target, runtime.sourcePath, dryRun, force); err != nil {
 				ui.Error("%s: %v", name, err)

--- a/cmd/skillshare/target.go
+++ b/cmd/skillshare/target.go
@@ -89,7 +89,7 @@ Options:
   --global, -g           Use global config (~/.config/skillshare)
 
 Target Settings:
-  <name> --mode <mode>              Set sync mode (merge or symlink)
+  <name> --mode <mode>              Set sync mode (merge, symlink, or copy)
   <name> --add-include <pattern>    Add an include filter pattern
   <name> --add-exclude <pattern>    Add an exclude filter pattern
   <name> --remove-include <pattern> Remove an include filter pattern
@@ -469,8 +469,8 @@ func targetInfo(name string, args []string) error {
 }
 
 func updateTargetMode(cfg *config.Config, name string, target config.TargetConfig, newMode string) error {
-	if newMode != "merge" && newMode != "symlink" {
-		return fmt.Errorf("invalid mode '%s'. Use 'merge' or 'symlink'", newMode)
+	if newMode != "merge" && newMode != "symlink" && newMode != "copy" {
+		return fmt.Errorf("invalid mode '%s'. Use 'merge', 'symlink', or 'copy'", newMode)
 	}
 
 	oldMode := target.Mode

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,7 +14,7 @@ import (
 // TargetConfig holds configuration for a single target
 type TargetConfig struct {
 	Path    string   `yaml:"path"`
-	Mode    string   `yaml:"mode,omitempty"` // symlink (default), copy
+	Mode    string   `yaml:"mode,omitempty"` // merge, symlink, or copy
 	Include []string `yaml:"include,omitempty"`
 	Exclude []string `yaml:"exclude,omitempty"`
 }
@@ -40,7 +40,7 @@ type HubConfig struct {
 // Config holds the application configuration
 type Config struct {
 	Source  string                  `yaml:"source"`
-	Mode    string                  `yaml:"mode,omitempty"` // default mode: symlink
+	Mode    string                  `yaml:"mode,omitempty"` // default mode: merge, symlink, or copy
 	Targets map[string]TargetConfig `yaml:"targets"`
 	Skills  []SkillEntry            `yaml:"skills,omitempty"`
 	Ignore  []string                `yaml:"ignore,omitempty"`

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -16,7 +16,7 @@
     "mode": {
       "type": "string",
       "description": "Default sync mode for all targets.",
-      "enum": ["merge", "symlink"],
+      "enum": ["merge", "symlink", "copy"],
       "default": "merge",
       "examples": ["merge"]
     },
@@ -71,7 +71,7 @@
         "mode": {
           "type": "string",
           "description": "Sync mode override for this target. If omitted, inherits the top-level mode.",
-          "enum": ["merge", "symlink"]
+          "enum": ["merge", "symlink", "copy"]
         },
         "include": {
           "type": "array",

--- a/website/docs/concepts/sync-modes.md
+++ b/website/docs/concepts/sync-modes.md
@@ -16,6 +16,7 @@ Choose merge mode (default) when you want per-skill symlinks and to preserve loc
 |------|----------|----------|
 | `merge` | Each skill symlinked individually | **Default.** Preserves local skills. |
 | `symlink` | Entire directory is one symlink | Exact copies everywhere. |
+| `copy` | Each skill copied (no symlinks) | When symlinks are not desired or supported. |
 
 ---
 
@@ -93,6 +94,26 @@ skillshare target remove claude   # ✅ Safe way to unlink
 
 ---
 
+## Copy Mode
+
+Each skill is **copied** into the target directory (no symlinks). Same filtering as merge mode (include/exclude, per-skill targets).
+
+**When to use:**
+- Symlinks are not supported or not desired (e.g. some network or shared filesystems)
+- You want a true snapshot of skills in the target; changes in source require `skillshare sync` to update the target
+
+**Behavior:**
+- `sync` copies each managed skill directory into the target (flat names, e.g. `my__nested__skill`)
+- Existing copies are left unchanged unless you run `sync --force` (then they are overwritten)
+- Orphan copies (skills removed from source) are pruned on sync
+
+```bash
+skillshare target claude --mode copy
+skillshare sync
+```
+
+---
+
 ## Changing Mode
 
 ### Per-target
@@ -105,6 +126,10 @@ skillshare sync
 # Switch back to merge mode
 skillshare target claude --mode merge
 skillshare sync
+
+# Use copy mode (no symlinks)
+skillshare target claude --mode copy
+skillshare sync
 ```
 
 ### Default mode
@@ -113,7 +138,7 @@ Set in config for new targets:
 
 ```yaml
 # ~/.config/skillshare/config.yaml
-mode: merge  # or symlink
+mode: merge  # or symlink, or copy
 
 targets:
   claude:
@@ -122,7 +147,7 @@ targets:
 
   codex:
     path: ~/.codex/skills
-    mode: symlink  # override default
+    mode: symlink  # override default (merge, symlink, or copy)
 ```
 
 ---


### PR DESCRIPTION
When config has mode: copy (global or per-target), sync copies each skill directory into the target instead of creating symlinks.

- internal/sync: SyncTargetCopy, CopyResult, PruneOrphanCopyDirs, CheckStatusCopy; copy respects include/exclude and --force overwrite
- cmd/skillshare: sync/sync_project branch on copy mode; target accepts --mode copy; status and doctor show copy mode and drift
- server: handleSync and handleDiff support copy mode
- config schema and docs: mode enum includes copy; sync-modes.md updated

Closes #31 #2 