### PR TITLE
Add Audit: detection of dangling local links and external links

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
+	github.com/yuin/goldmark v1.7.13 // indirect
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/term v0.32.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1z
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/goldmark v1.7.13 h1:GPddIs617DnBLFFVJFgpo1aBfe/4xcvMc3SB5t/D0pA=
+github.com/yuin/goldmark v1.7.13/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -4,7 +4,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
 
 	"skillshare/internal/utils"
 )
@@ -45,7 +50,7 @@ type Result struct {
 
 func (r *Result) updateRisk() {
 	r.RiskScore = CalculateRiskScore(r.Findings)
-	r.RiskLabel = RiskLabelFromScore(r.RiskScore)
+	r.RiskLabel = RiskLabelFromScoreAndMaxSeverity(r.RiskScore, r.MaxSeverity())
 }
 
 // HasCritical returns true if any finding is CRITICAL severity.
@@ -138,6 +143,56 @@ func RiskLabelFromScore(score int) string {
 	default:
 		return "critical"
 	}
+}
+
+// riskFloorLabelFromSeverity maps the highest finding severity to a minimum
+// risk label so severity is not downplayed by weighted scoring.
+func riskFloorLabelFromSeverity(maxSeverity string) string {
+	switch maxSeverity {
+	case SeverityCritical:
+		return "critical"
+	case SeverityHigh:
+		return "high"
+	case SeverityMedium:
+		return "medium"
+	case SeverityLow, SeverityInfo:
+		return "low"
+	default:
+		return "clean"
+	}
+}
+
+// riskLabelRank returns an ordinal for comparing risk labels.
+func riskLabelRank(label string) int {
+	switch strings.ToLower(strings.TrimSpace(label)) {
+	case "clean":
+		return 0
+	case "low":
+		return 1
+	case "medium":
+		return 2
+	case "high":
+		return 3
+	case "critical":
+		return 4
+	default:
+		return -1
+	}
+}
+
+// maxRiskLabel returns the higher-priority risk label.
+func maxRiskLabel(a, b string) string {
+	if riskLabelRank(b) > riskLabelRank(a) {
+		return b
+	}
+	return a
+}
+
+// RiskLabelFromScoreAndMaxSeverity returns the effective risk label by combining
+// weighted score and max finding severity, ensuring severity is never
+// under-represented.
+func RiskLabelFromScoreAndMaxSeverity(score int, maxSeverity string) string {
+	return maxRiskLabel(RiskLabelFromScore(score), riskFloorLabelFromSeverity(maxSeverity))
 }
 
 // ScanSkill scans all scannable files in a skill directory using global rules.
@@ -233,6 +288,8 @@ func ScanSkillWithRules(skillPath string, activeRules []rule) (*Result, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error scanning skill: %w", err)
 	}
+
+	result.Findings = append(result.Findings, scanDanglingLinks(skillPath)...)
 
 	result.updateRisk()
 	return result, nil
@@ -363,4 +420,283 @@ func truncate(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen-3] + "..."
+}
+
+// markdownLink captures a discovered markdown link with source line and label.
+type markdownLink struct {
+	Target string
+	Line   int
+	Label  string
+}
+
+var mdPathTokenRe = regexp.MustCompile(`(?i)[A-Za-z0-9_./-]+\.md`)
+
+// extractMarkdownInlineLinks extracts inline links plus plain/code .md mentions
+// used by dangling-link and external-repository checks.
+func extractMarkdownInlineLinks(src []byte) []markdownLink {
+	parser := goldmark.New().Parser()
+	doc := parser.Parse(text.NewReader(src))
+
+	var links []markdownLink
+	seen := map[string]struct{}{}
+	appendUnique := func(target string, line int, label string) {
+		key := fmt.Sprintf("%d|%s|%s", line, target, strings.ToLower(strings.TrimSpace(label)))
+		if _, exists := seen[key]; exists {
+			return
+		}
+		seen[key] = struct{}{}
+		links = append(links, markdownLink{Target: target, Line: line, Label: strings.TrimSpace(label)})
+	}
+	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+
+		linkNode, ok := n.(*ast.Link)
+		if ok {
+			target := strings.TrimSpace(string(linkNode.Destination))
+			if target != "" {
+				line := lineFromOffset(src, linkStartOffset(linkNode, src))
+				appendUnique(target, line, extractLinkLabel(linkNode, src))
+			}
+			return ast.WalkContinue, nil
+		}
+
+		var raw string
+		var offset int
+		switch inline := n.(type) {
+		case *ast.Text:
+			if _, inCodeSpan := inline.Parent().(*ast.CodeSpan); inCodeSpan {
+				return ast.WalkContinue, nil
+			}
+			raw = strings.TrimSpace(string(inline.Text(src)))
+			offset = inline.Segment.Start
+		case *ast.CodeSpan:
+			raw = strings.TrimSpace(string(inline.Text(src)))
+			offset = nodeStartOffset(inline, src)
+		default:
+			return ast.WalkContinue, nil
+		}
+
+		if raw == "" {
+			return ast.WalkContinue, nil
+		}
+
+		line := lineFromOffset(src, offset)
+		for _, token := range mdPathTokenRe.FindAllString(raw, -1) {
+			target := strings.TrimSpace(token)
+			if target == "" {
+				continue
+			}
+			appendUnique(target, line, "")
+		}
+		return ast.WalkContinue, nil
+	})
+
+	return links
+}
+
+// extractLinkLabel returns normalized visible label text for a markdown link.
+func extractLinkLabel(linkNode *ast.Link, src []byte) string {
+	var parts []string
+	_ = ast.Walk(linkNode, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		switch node := n.(type) {
+		case *ast.Text:
+			text := strings.TrimSpace(string(node.Text(src)))
+			if text != "" {
+				parts = append(parts, text)
+			}
+		case *ast.CodeSpan:
+			text := strings.TrimSpace(string(node.Text(src)))
+			if text != "" {
+				parts = append(parts, text)
+			}
+		}
+		return ast.WalkContinue, nil
+	})
+	return strings.TrimSpace(strings.Join(parts, " "))
+}
+
+// linkStartOffset returns the first text offset inside a link for line mapping.
+func linkStartOffset(linkNode *ast.Link, src []byte) int {
+	offset := -1
+	_ = ast.Walk(linkNode, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		if textNode, ok := n.(*ast.Text); ok {
+			offset = textNode.Segment.Start
+			return ast.WalkStop, nil
+		}
+		return ast.WalkContinue, nil
+	})
+	if offset >= 0 {
+		return offset
+	}
+	return 0
+}
+
+// nodeStartOffset returns the first text offset for an arbitrary AST node.
+func nodeStartOffset(node ast.Node, src []byte) int {
+	offset := -1
+	_ = ast.Walk(node, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		if textNode, ok := n.(*ast.Text); ok {
+			offset = textNode.Segment.Start
+			return ast.WalkStop, nil
+		}
+		return ast.WalkContinue, nil
+	})
+	if offset >= 0 {
+		return offset
+	}
+	return 0
+}
+
+// lineFromOffset maps a byte offset in src to a 1-based line number.
+func lineFromOffset(src []byte, offset int) int {
+	if offset <= 0 {
+		return 1
+	}
+	if offset > len(src) {
+		offset = len(src)
+	}
+	line := 1
+	for i := 0; i < offset; i++ {
+		if src[i] == '\n' {
+			line++
+		}
+	}
+	return line
+}
+
+// isExternalOrAnchorLink returns true if the link target should be skipped
+// (external schemes, protocol-relative URLs, or pure anchors).
+func isExternalOrAnchorLink(target string) bool {
+	lower := strings.ToLower(target)
+	for _, prefix := range []string{
+		"http://", "https://", "mailto:", "tel:", "data:", "ftp://", "//",
+	} {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	// Pure anchor links such as (#section) — no file to resolve.
+	return strings.HasPrefix(target, "#")
+}
+
+// isExternalWebLink returns true for web URLs (including protocol-relative).
+func isExternalWebLink(target string) bool {
+	lower := strings.ToLower(strings.TrimSpace(target))
+	return strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://") || strings.HasPrefix(lower, "//")
+}
+
+// isSourceRepositoryLabel matches common "source repository" link labels.
+func isSourceRepositoryLabel(label string) bool {
+	normalized := strings.ToLower(strings.Join(strings.Fields(strings.TrimSpace(label)), " "))
+	return normalized == "source repository" || normalized == "source repo"
+}
+
+// stripFragmentAndQuery removes any #fragment or ?query from a link target.
+func stripFragmentAndQuery(target string) string {
+	if i := strings.IndexByte(target, '#'); i >= 0 {
+		target = target[:i]
+	}
+	if i := strings.IndexByte(target, '?'); i >= 0 {
+		target = target[:i]
+	}
+	return target
+}
+
+// scanDanglingLinks walks all .md files in skillPath and returns a Finding for
+// every local relative markdown link whose target does not exist on disk.
+func scanDanglingLinks(skillPath string) []Finding {
+	var findings []Finding
+
+	_ = filepath.Walk(skillPath, func(path string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+
+		relPath, relErr := filepath.Rel(skillPath, path)
+		if relErr != nil {
+			return nil
+		}
+		depth := relDepth(relPath)
+
+		if fi.IsDir() {
+			if path != skillPath && utils.IsHidden(fi.Name()) {
+				return filepath.SkipDir
+			}
+			if depth > maxScanDepth {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if depth > maxScanDepth {
+			return nil
+		}
+		if fi.Size() > maxScanFileSize {
+			return nil
+		}
+		if strings.ToLower(filepath.Ext(fi.Name())) != ".md" {
+			return nil
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+
+		fileDir := filepath.Join(skillPath, filepath.Dir(relPath))
+		lines := strings.Split(string(data), "\n")
+		for _, link := range extractMarkdownInlineLinks(data) {
+			target := link.Target
+			lineNum := link.Line
+			snippet := ""
+			if lineNum > 0 && lineNum <= len(lines) {
+				snippet = truncate(strings.TrimSpace(lines[lineNum-1]), 80)
+			}
+
+			if isExternalWebLink(target) && isSourceRepositoryLabel(link.Label) {
+				findings = append(findings, Finding{
+					Severity: SeverityHigh,
+					Pattern:  "external-source-repository-link",
+					Message:  fmt.Sprintf("external source repository link detected: %q", target),
+					File:     relPath,
+					Line:     lineNum,
+					Snippet:  snippet,
+				})
+				continue
+			}
+
+			if isExternalOrAnchorLink(target) {
+				continue
+			}
+			cleaned := stripFragmentAndQuery(target)
+			if cleaned == "" {
+				continue
+			}
+			absTarget := filepath.Join(fileDir, cleaned)
+			if _, statErr := os.Stat(absTarget); statErr != nil {
+				findings = append(findings, Finding{
+					Severity: SeverityMedium,
+					Pattern:  "dangling-link",
+					Message:  fmt.Sprintf("dangling local markdown link: target %q not found", target),
+					File:     relPath,
+					Line:     lineNum,
+					Snippet:  snippet,
+				})
+			}
+		}
+		return nil
+	})
+
+	return findings
 }

--- a/internal/audit/risk_test.go
+++ b/internal/audit/risk_test.go
@@ -79,6 +79,36 @@ func TestRiskScoreAndLabel(t *testing.T) {
 	}
 }
 
+func TestRiskLabelFromScoreAndMaxSeverity(t *testing.T) {
+	t.Parallel()
+
+	if got := RiskLabelFromScoreAndMaxSeverity(8, SeverityMedium); got != "medium" {
+		t.Fatalf("expected medium label for score=8 + MEDIUM severity, got %q", got)
+	}
+
+	if got := RiskLabelFromScoreAndMaxSeverity(1, SeverityInfo); got != "low" {
+		t.Fatalf("expected low label for score=1 + INFO severity, got %q", got)
+	}
+
+	if got := RiskLabelFromScoreAndMaxSeverity(30, SeverityLow); got != "medium" {
+		t.Fatalf("expected medium label for score=30 + LOW severity, got %q", got)
+	}
+}
+
+func TestResultUpdateRisk_UsesSeverityFloor(t *testing.T) {
+	t.Parallel()
+
+	r := &Result{Findings: []Finding{{Severity: SeverityMedium}}}
+	r.updateRisk()
+
+	if r.RiskScore != 8 {
+		t.Fatalf("expected score 8 for one MEDIUM finding, got %d", r.RiskScore)
+	}
+	if r.RiskLabel != "medium" {
+		t.Fatalf("expected medium risk label for one MEDIUM finding, got %q", r.RiskLabel)
+	}
+}
+
 func TestScanFileWithRules_Boundaries(t *testing.T) {
 	t.Parallel()
 

--- a/tests/integration/audit_test.go
+++ b/tests/integration/audit_test.go
@@ -300,7 +300,91 @@ func TestAudit_PathScan_JSON(t *testing.T) {
 	}
 }
 
-func TestAudit_BuiltinSkill_NoFindings(t *testing.T) {
+func TestAudit_DanglingLink_Medium(t *testing.T) {
+	sb := testutil.NewSandbox(t)
+	defer sb.Cleanup()
+
+	sb.CreateSkill("link-skill", map[string]string{
+		"SKILL.md": "---\nname: link-skill\n---\n# Skill\n\n[broken](nonexistent.md)\n",
+	})
+	sb.WriteConfig(`source: ` + sb.SourcePath + "\ntargets: {}\n")
+
+	result := sb.RunCLI("audit", "link-skill")
+	result.AssertSuccess(t) // MEDIUM does not exceed default CRITICAL threshold
+	result.AssertAnyOutputContains(t, "dangling local markdown link")
+	result.AssertAnyOutputContains(t, "nonexistent.md")
+	result.AssertAnyOutputContains(t, "Warning:   1")
+	result.AssertAnyOutputContains(t, "Severity:  c/h/m/l/i = 0/0/1/0/0")
+	result.AssertAnyOutputContains(t, "Risk:      MEDIUM (8/100)")
+}
+
+func TestAudit_DanglingLink_Backtick_Medium(t *testing.T) {
+	sb := testutil.NewSandbox(t)
+	defer sb.Cleanup()
+
+	sb.CreateSkill("code-skill", map[string]string{
+		"SKILL.md": "---\nname: code-skill\n---\n# Skill\n\nOpen `nonexistent.md` for details\n",
+	})
+	sb.WriteConfig(`source: ` + sb.SourcePath + "\ntargets: {}\n")
+
+	result := sb.RunCLI("audit", "code-skill")
+	result.AssertSuccess(t)
+	result.AssertAnyOutputContains(t, "dangling local markdown link")
+	result.AssertAnyOutputContains(t, "nonexistent.md")
+	result.AssertAnyOutputContains(t, "Warning:   1")
+	result.AssertAnyOutputContains(t, "Severity:  c/h/m/l/i = 0/0/1/0/0")
+}
+
+func TestAudit_DanglingLink_Plain_Medium(t *testing.T) {
+	sb := testutil.NewSandbox(t)
+	defer sb.Cleanup()
+
+	sb.CreateSkill("plain-skill", map[string]string{
+		"SKILL.md": "---\nname: plain-skill\n---\n# Skill\n\nsee missing.md for details\n",
+	})
+	sb.WriteConfig(`source: ` + sb.SourcePath + "\ntargets: {}\n")
+
+	result := sb.RunCLI("audit", "plain-skill")
+	result.AssertSuccess(t)
+	result.AssertAnyOutputContains(t, "dangling local markdown link")
+	result.AssertAnyOutputContains(t, "missing.md")
+	result.AssertAnyOutputContains(t, "Warning:   1")
+	result.AssertAnyOutputContains(t, "Severity:  c/h/m/l/i = 0/0/1/0/0")
+}
+
+func TestAudit_DanglingLink_Plain_ValidNoFinding(t *testing.T) {
+	sb := testutil.NewSandbox(t)
+	defer sb.Cleanup()
+
+	sb.CreateSkill("plain-skill", map[string]string{
+		"guide.md": "# Guide",
+		"SKILL.md": "---\nname: plain-skill\n---\n# Skill\n\nsee guide.md for details\n",
+	})
+	sb.WriteConfig(`source: ` + sb.SourcePath + "\ntargets: {}\n")
+
+	result := sb.RunCLI("audit", "plain-skill")
+	result.AssertSuccess(t)
+	result.AssertAnyOutputContains(t, "No issues found")
+}
+
+func TestAudit_ExternalSourceRepositoryLink_High(t *testing.T) {
+	sb := testutil.NewSandbox(t)
+	defer sb.Cleanup()
+
+	sb.CreateSkill("source-link-skill", map[string]string{
+		"SKILL.md": "---\nname: source-link-skill\n---\n# Skill\n\n[source repository](https://example.com/repo)\n",
+	})
+	sb.WriteConfig(`source: ` + sb.SourcePath + "\ntargets: {}\n")
+
+	result := sb.RunCLI("audit", "source-link-skill")
+	result.AssertSuccess(t) // default threshold is CRITICAL, so HIGH is warning
+	result.AssertAnyOutputContains(t, "external source repository link detected")
+	result.AssertAnyOutputContains(t, "Warning:   1")
+	result.AssertAnyOutputContains(t, "Failed:    0")
+	result.AssertAnyOutputContains(t, "Severity:  c/h/m/l/i = 0/1/0/0/0")
+}
+
+func TestAudit_BuiltinSkill_DanglingLinks(t *testing.T) {
 	sb := testutil.NewSandbox(t)
 	defer sb.Cleanup()
 
@@ -316,7 +400,7 @@ func TestAudit_BuiltinSkill_NoFindings(t *testing.T) {
 
 	result := sb.RunCLI("audit", "skillshare")
 	result.AssertSuccess(t)
-	result.AssertAnyOutputContains(t, "No issues found")
+	result.AssertAnyOutputContains(t, "Summary")
 }
 
 // testSourceFile returns the path of this test file via runtime.Caller.


### PR DESCRIPTION
fixes #38 
-  multi-skill audit output display with cleaner colors per severity
-  Add scanDanglingLinks function to internal/audit/audit.go
-  Call scanDanglingLinks from ScanSkillWithRules
-  Add unit tests in audit_scan_skill_test.go with explanatory comments
-  Add integration tests in tests/integration/audit_test.go