### PR TITLE
feat(ui): add copy-to-clipboard for skill paths

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@codemirror/lang-javascript": "^6.2.4",
@@ -32,6 +33,9 @@
   "devDependencies": {
     "@eslint/js": "^9.39.1",
     "@tanstack/react-query-devtools": "^5.91.3",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
@@ -40,8 +44,10 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "jsdom": "^28.1.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
-    "vite": "^7.2.4"
+    "vite": "^7.2.4",
+    "vitest": "^4.0.18"
   }
 }

--- a/ui/src/components/CopyButton.test.tsx
+++ b/ui/src/components/CopyButton.test.tsx
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { ToastProvider } from './Toast';
+import CopyButton from './CopyButton';
+
+describe('CopyButton', () => {
+  const writeText = vi.fn();
+
+  beforeEach(() => {
+    writeText.mockReset();
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function renderButton() {
+    return render(
+      <ToastProvider>
+        <CopyButton value="/tmp/skills/example/SKILL.md" />
+      </ToastProvider>,
+    );
+  }
+
+  it('shows copied feedback after a successful clipboard write', async () => {
+    writeText.mockResolvedValue(undefined);
+
+    renderButton();
+    fireEvent.click(screen.getByRole('button', { name: /copy to clipboard/i }));
+
+    expect(writeText).toHaveBeenCalledWith('/tmp/skills/example/SKILL.md');
+    expect(await screen.findByText('Copied!')).toBeInTheDocument();
+
+    await waitForElementToBeRemoved(() => screen.queryByText('Copied!'), { timeout: 2500 });
+  });
+
+  it('shows an error toast when clipboard access is denied', async () => {
+    writeText.mockRejectedValue(new Error('denied'));
+
+    renderButton();
+    fireEvent.click(screen.getByRole('button', { name: /copy to clipboard/i }));
+
+    expect(await screen.findByText('Failed to copy to clipboard.')).toBeInTheDocument();
+  });
+
+  it('clears stale copied feedback when a later copy attempt fails', async () => {
+    writeText
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('denied'));
+
+    renderButton();
+
+    const button = screen.getByRole('button', { name: /copy to clipboard/i });
+    fireEvent.click(button);
+    expect(await screen.findByText('Copied!')).toBeInTheDocument();
+
+    fireEvent.click(button);
+
+    expect(await screen.findByText('Failed to copy to clipboard.')).toBeInTheDocument();
+    expect(screen.queryByText('Copied!')).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/components/CopyButton.tsx
+++ b/ui/src/components/CopyButton.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useRef, useState, type CSSProperties } from 'react';
+import { Check, Copy } from 'lucide-react';
+import { useToast } from './Toast';
+
+interface CopyButtonProps {
+  value: string;
+  title?: string;
+  className?: string;
+  style?: CSSProperties;
+  copiedLabel?: string;
+  copiedLabelClassName?: string;
+  errorMessage?: string;
+  size?: number;
+  strokeWidth?: number;
+}
+
+const baseClassName = 'inline-flex items-center gap-0.5 text-pencil-light hover:text-pencil transition-colors cursor-pointer shrink-0';
+
+export default function CopyButton({
+  value,
+  title = 'Copy to clipboard',
+  className,
+  style,
+  copiedLabel = 'Copied!',
+  copiedLabelClassName = 'text-xs',
+  errorMessage = 'Failed to copy to clipboard.',
+  size = 12,
+  strokeWidth = 2.5,
+}: CopyButtonProps) {
+  const { toast } = useToast();
+  const [copied, setCopied] = useState(false);
+  const resetTimeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimeoutRef.current !== null) {
+        window.clearTimeout(resetTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      if (resetTimeoutRef.current !== null) {
+        window.clearTimeout(resetTimeoutRef.current);
+      }
+      resetTimeoutRef.current = window.setTimeout(() => {
+        setCopied(false);
+        resetTimeoutRef.current = null;
+      }, 1500);
+    } catch {
+      setCopied(false);
+      if (resetTimeoutRef.current !== null) {
+        window.clearTimeout(resetTimeoutRef.current);
+        resetTimeoutRef.current = null;
+      }
+      toast(errorMessage, 'error');
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className={className ? `${baseClassName} ${className}` : baseClassName}
+      style={style}
+      title={title}
+      aria-label={title}
+    >
+      {copied ? (
+        <>
+          <Check size={size} strokeWidth={strokeWidth} />
+          <span className={copiedLabelClassName}>{copiedLabel}</span>
+        </>
+      ) : (
+        <Copy size={size} strokeWidth={strokeWidth} />
+      )}
+    </button>
+  );
+}

--- a/ui/src/components/FileViewerModal.tsx
+++ b/ui/src/components/FileViewerModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { X, Copy, Check } from 'lucide-react';
+import { X } from 'lucide-react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import CodeMirror from '@uiw/react-codemirror';
@@ -9,6 +9,7 @@ import { python } from '@codemirror/lang-python';
 import { javascript } from '@codemirror/lang-javascript';
 import { EditorView } from '@codemirror/view';
 import Card from './Card';
+import CopyButton from './CopyButton';
 import HandButton from './HandButton';
 import { api, type SkillFileContent } from '../api/client';
 import { handTheme } from '../lib/codemirror-theme';
@@ -22,14 +23,7 @@ interface FileViewerModalProps {
 }
 
 export default function FileViewerModal({ skillName, filepath, sourcePath, onClose }: FileViewerModalProps) {
-  const [copied, setCopied] = useState(false);
   const fullPath = sourcePath ? `${sourcePath}/${filepath}` : filepath;
-  const handleCopy = () => {
-    navigator.clipboard.writeText(fullPath).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    });
-  };
   const [data, setData] = useState<SkillFileContent | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -91,14 +85,11 @@ export default function FileViewerModal({ skillName, filepath, sourcePath, onClo
               style={{ fontFamily: "'Courier New', monospace", fontSize: '0.95rem' }}
             >
               {filepath}
-              <button
-                type="button"
-                onClick={handleCopy}
-                className="inline-flex items-center gap-0.5 text-pencil-light hover:text-pencil transition-colors cursor-pointer shrink-0"
+              <CopyButton
+                value={fullPath}
                 title="Copy file path"
-              >
-                {copied ? <><Check size={12} strokeWidth={2.5} /> <span className="text-xs font-normal">Copied!</span></> : <Copy size={12} strokeWidth={2.5} />}
-              </button>
+                copiedLabelClassName="text-xs font-normal"
+              />
             </h3>
             <HandButton variant="ghost" size="sm" onClick={onClose} className="shrink-0 ml-2">
               <X size={16} strokeWidth={2.5} />

--- a/ui/src/pages/SkillDetailPage.tsx
+++ b/ui/src/pages/SkillDetailPage.tsx
@@ -3,7 +3,7 @@ import {
   ArrowLeft, Trash2, ExternalLink, FileText, ArrowUpRight, RefreshCw, Target,
   Type, AlignLeft, Files, Scale,
   FileCode2, Braces, Settings, BookOpen, File, FolderOpen,
-  ShieldCheck, Link2, Copy, Check,
+  ShieldCheck, Link2,
 } from 'lucide-react';
 import Markdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -11,6 +11,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { queryKeys, staleTimes } from '../lib/queryKeys';
 import Badge from '../components/Badge';
 import Card from '../components/Card';
+import CopyButton from '../components/CopyButton';
 import HandButton from '../components/HandButton';
 import { PageSkeleton } from '../components/Skeleton';
 import { useToast } from '../components/Toast';
@@ -621,7 +622,13 @@ function MetaItem({
     <div>
       <dt className="text-sm text-pencil-light uppercase tracking-wider flex items-center gap-1">
         {label}
-        {copyable && <CopyButton value={copyValue ?? value} />}
+        {copyable && (
+          <CopyButton
+            value={copyValue ?? value}
+            className="align-middle ml-1.5"
+            style={{ position: 'relative', top: '1px' }}
+          />
+        )}
       </dt>
       <dd
         className="text-base text-pencil break-all"
@@ -630,26 +637,6 @@ function MetaItem({
         {value}
       </dd>
     </div>
-  );
-}
-
-function CopyButton({ value }: { value: string }) {
-  const [copied, setCopied] = useState(false);
-  return (
-    <button
-      type="button"
-      onClick={() => {
-        navigator.clipboard.writeText(value).then(() => {
-          setCopied(true);
-          setTimeout(() => setCopied(false), 1500);
-        });
-      }}
-      className="inline-flex items-center gap-0.5 align-middle ml-1.5 text-pencil-light hover:text-pencil transition-colors cursor-pointer shrink-0"
-      style={{ position: 'relative', top: '1px' }}
-      title="Copy to clipboard"
-    >
-      {copied ? <><Check size={12} strokeWidth={2.5} /> <span className="text-xs">Copied!</span></> : <Copy size={12} strokeWidth={2.5} />}
-    </button>
   );
 }
 

--- a/ui/src/test/setup.ts
+++ b/ui/src/test/setup.ts
@@ -1,0 +1,7 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+});

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,3 +1,5 @@
+/// <reference types="vitest/config" />
+
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
@@ -7,6 +9,10 @@ const SSE_PROXY = { target: 'http://localhost:19420', headers: { Accept: 'text/e
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.ts',
+  },
   resolve: {
     dedupe: ['react', 'react-dom'],
   },


### PR DESCRIPTION
## Summary
- Adds a copy button (overlapping-squares icon) next to the "Path" label in the Metadata card on the skill detail page — copies the full absolute source path
- Adds the same copy button in the file viewer modal header next to the filename — copies the full file path
- Clicking shows a brief checkmark with "Copied!" confirmation

## Test plan
- [x] Open a skill detail page, click the copy icon next to "Path" — verify full absolute path is copied
- [x] Open a file in the file viewer modal, click the copy icon next to the filename — verify full file path is copied
- [x] Confirm "Copied!" feedback appears briefly after clicking