### PR TITLE
Implemented Subdirectory Specification for Source

### DIFF
--- a/cmd/skillshare/init.go
+++ b/cmd/skillshare/init.go
@@ -1236,7 +1236,6 @@ func tryPullAfterRemoteSetup(sourcePath, remoteURL string) bool {
 func useSourceSubdir() string {
 	fmt.Println()
 	fmt.Println("  Specifying a subdirectory as the source will store skills in the subdirectory (e.g. skills/) instead of in the root")
-	fmt.Println()
 	fmt.Print("  Specify a subdirectory as the source (e.g. skills)? [y/N]: ")
 	var input string
 	fmt.Scanln(&input)
@@ -1244,8 +1243,7 @@ func useSourceSubdir() string {
 
 	if input == "y" || input == "yes" {
 		fmt.Print("  Enter subdirectory name: ")
-		var dirNameInput string
-		fmt.Scanln(&dirNameInput)
+		dirNameInput, _ := bufio.NewReader(os.Stdin).ReadString('\n')
 		return strings.TrimSpace(dirNameInput)
 	}
 	return ""


### PR DESCRIPTION
Add a prompt to the `init` command to allow users to specify a subdirectory as the source, allowing users to be able to store their skills in a `skills/` directory in their repo and not the root. Resolves #74 

Changelog:
- Created `useSourceSubdir` function that prompts the user and returns a string that is non-empty if the user specified
- Joined the subdirectory specified to the existing source path and create the directory if it does not exist
- Movedd the configuration saving to after the subdir prompting as from what I can see, `initGitIfNeeded` and `setupGitRemote` do not rely on the configuration.

There is a caveat that this introduces where if a user already initialised but did not setup a repository and then runs `skillshare init --remote REMOTEURL`, it will initialise the git repository and remote in the subdirectory and not the parent directory. This is due to the program not having knowledge that it is a subdirectory and not the parent.
I think this is an acceptable edge case as for a user to perform that, they already did not follow the recommended guidance and then are establishing the remote after the fact and I would want to expect such a user to check that it is in the appropriate dir if they care about the skills being in the source subdir. The fix would also just be moving the `.git/` directory up a level which is minimal effort.