### PR TITLE
Update info message from `git stash` to `git stash -u`

### DIFF
--- a/cmd/skillshare/pull.go
+++ b/cmd/skillshare/pull.go
@@ -78,7 +78,7 @@ func pullFromRemote(cfg *config.Config, dryRun, force bool) error {
 	if len(strings.TrimSpace(string(output))) > 0 {
 		spinner.Fail("Local changes detected")
 		ui.Info("  Run: skillshare push")
-		ui.Info("  Or:  cd %s && git stash", cfg.Source)
+		ui.Info("  Or:  cd %s && git stash -u", cfg.Source)
 		return nil
 	}
 


### PR DESCRIPTION
Generally when there is a diff, it is mostly with untracked files. Since `skillshare` might also be used by non-engineers for general purpose skillshare platform, a ready copy paste command with `-u` might be helpful on the info log