### PR TITLE
Support custom INSTALL_DIR variable in `install.sh`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,9 @@ set -e
 
 REPO="runkids/skillshare"
 BINARY_NAME="skillshare"
-INSTALL_DIR="/usr/local/bin"
+if [ -z "${INSTALL_DIR}" ]; then
+	INSTALL_DIR="/usr/local/bin"
+fi
 
 # Colors (if terminal supports it)
 RED='\033[0;31m'


### PR DESCRIPTION
There may be cases where user wants the install dir to be different. Such as `~/.local/bin/` or `pwd` depending on use case and environment.

I noticed this when I was trying to make this work on Github Actions (enterprise), to be able to use it as a package manager and needed a different INSTALL_DIR due to permission issues.

Having said that, it'd be nice to have a Github Action for this too.


Tested on local

```

╰─$ export INSTALL_DIR=`pwd`

╰─$ cat install.sh | bash
Installing skillshare...

Downloading skillshare 0.18.3 for darwin/arm64...

Successfully installed skillshare to /Users/hide.hide/git/oss/skillshare/skillshare

     _    _ _ _     _
 ___| | _(_) | |___| |__   __ _ _ __ ___
/ __| |/ / | | / __| '_ \ / _` | '__/ _ \
\__ \   <| | | \__ \ | | | (_| | | |  __/  https://github.com/runkids/skillshare
|___/_|\_\_|_|_|___/_| |_|\__,_|_|  \___|  v0.18.3


Get started:
  skillshare init
  skillshare --help
```