### PR TITLE
v0.19.1

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!-- Thanks for contributing! Please read CONTRIBUTING.md before submitting. -->
+
+## Type
+
+- [ ] Bug fix
+- [ ] Small improvement (docs, typo, minor refactor)
+- [ ] Feature proposal (`proposals/` only — see [CONTRIBUTING.md](../CONTRIBUTING.md))
+
+## Linked Issue
+
+<!-- Recommended for bug fixes. Required for proposals. -->
+
+Closes #
+
+## Checklist
+
+- [ ] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [ ] Tests included and passing (`make check`) — for code changes
+- [ ] No unrelated changes in the diff
+- [ ] Scope is focused — one concern per PR

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ docs/superpowers/
 !.skillshare/registry.yaml
 !.skillshare/.gitignore
 /specs/
+!/proposals/
 .pnpm-store/
 .feature-radar/
 .cache/

--- a/.skillshare/registry.yaml
+++ b/.skillshare/registry.yaml
@@ -1,4 +1,0 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/runkids/skillshare/main/schemas/registry.schema.json
-skills:
-  - name: mdproof
-    source: github.com/runkids/mdproof/skills

--- a/.skillshare/skills/.metadata.json
+++ b/.skillshare/skills/.metadata.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "entries": {
+    "mdproof": {
+      "source": "github.com/runkids/mdproof/skills"
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.19.1] - 2026-04-13
+
+### Bug Fixes
+
+- **Structured output no longer corrupted by update notices** — `--json`, `-j`, and `--format json/sarif/markdown` modes could emit a trailing human-readable update notification into stdout, producing invalid JSON for downstream consumers. The update check is now skipped entirely in structured-output modes, and the notification itself writes to stderr as a safety net. Refs: #129
+
 ## [0.19.0] - 2026-04-11
 
 ### New Features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,76 +2,74 @@
 
 Thanks for your interest in contributing! This guide helps you get started.
 
-## How to Contribute
+## Start with an Issue
 
-### 1. Open an Issue First
+The best way to contribute is to [open an issue](https://github.com/runkids/skillshare/issues/new). Issues are where ideas, feature requests, and design discussions happen. This helps us:
 
-Before writing code, [open an issue](https://github.com/runkids/skillshare/issues/new) to describe what you'd like to change and why. This helps us:
+- Align on whether the change fits the project direction
+- Agree on scope and approach before any code is written
+- Avoid investing time in work that may not be merged
 
-- Align on the scope and approach
-- Avoid duplicate effort
-- Discuss alternative solutions early
+**Please open an issue before writing code**, even if you're confident in the approach. Skipping this step is the most common reason contributions can't be accepted.
 
-Even small changes benefit from a quick issue — it gives context for reviewers and future contributors.
+## Pull Requests
 
-### 2. Submit a Draft PR
+### What PRs are good for
 
-If you'd like to propose an implementation, open a [draft pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests) and link it to the issue. Draft PRs let us:
+PRs work best for **small, focused changes**:
 
-- Collaborate on the approach before investing time in polish
-- Catch design mismatches early
-- Provide incremental feedback
+- Bug fixes with a clear reproduction
+- Typo and documentation corrections
+- Small improvements (a few files, under ~200 lines of meaningful change)
 
-> **Note:** Due to the nature of this project, most PRs won't be merged directly — but every contribution is valuable. Your draft PR serves as a concrete reference that shapes the final implementation.
+These can go straight to a PR (still link to an issue if one exists).
 
-### 3. Include Tests
+### Feature Ideas
 
-PRs with test coverage are much easier to review and merge. skillshare has both unit and integration tests:
+For new features or large changes:
 
-- **Unit tests**: alongside source files (`*_test.go`)
-- **Integration tests**: `tests/integration/` using `testutil.Sandbox`
+1. **Open an issue** to describe the idea and the problem it solves
+2. **Submit a proposal** — copy [`proposals/TEMPLATE.md`](proposals/TEMPLATE.md), fill it in, and open a PR to `proposals/`
 
-Run the full check before submitting:
+Approved proposals will be added to the roadmap. Implementation is handled by the maintainer to ensure consistency with the project's architecture and codebase conventions.
 
-```bash
-make check          # format + lint + unit + integration tests
-```
+> **Note:** Due to the nature of this project, most feature PRs won't be merged directly — but every contribution is valuable. Your PR serves as a concrete reference that shapes the final implementation.
+
+### PR Checklist
+
+- [ ] Linked to an issue (required for features, recommended for bug fixes)
+- [ ] Tests included and passing (`make check`)
+- [ ] No unrelated changes in the diff
+- [ ] Commit messages explain "why", not just "what"
+- [ ] Scope is focused — one concern per PR
 
 ## Development Setup
 
-### Option A: Dev Containers (Recommended)
-
-Open in [Dev Containers](https://containers.dev/) — Go toolchain, Node.js, pnpm, and demo content are pre-configured.
-
-### Option B: Local
-
-Requirements: Go 1.23+
+All development and testing should be done inside the **devcontainer**. This ensures a consistent environment (Go toolchain, Node.js, pnpm, and demo content are pre-configured).
 
 ```bash
 git clone https://github.com/runkids/skillshare.git
 cd skillshare
-make build          # build binary
-make check          # format + lint + test
+make devc            # start devcontainer + enter shell (one step)
 ```
 
-### Useful Commands
+Once inside the devcontainer:
 
 ```bash
-make build          # build binary → bin/skillshare
-make test           # unit + integration tests
-make test-unit      # unit tests only
-make lint           # go vet
-make fmt            # gofmt
-make check          # fmt + lint + test (must pass before PR)
-make ui-dev         # Go API server + Vite HMR for Web UI
+make build           # build binary → bin/skillshare
+make test            # unit + integration tests
+make check           # fmt + lint + test (must pass before PR)
+make ui-dev          # Go API server + Vite HMR for Web UI
 ```
 
-## PR Checklist
+Other devcontainer commands:
 
-- [ ] Linked to an issue
-- [ ] Tests included and passing (`make check`)
-- [ ] No unrelated changes in the diff
-- [ ] Commit messages explain "why", not just "what"
+```bash
+make devc-down       # stop devcontainer
+make devc-restart    # restart devcontainer
+make devc-reset      # full reset (remove volumes)
+make devc-status     # show devcontainer status
+```
 
 ## Questions?
 

--- a/cmd/skillshare/json_output.go
+++ b/cmd/skillshare/json_output.go
@@ -117,6 +117,25 @@ func hasFlag(args []string, flag string) bool {
 	return slices.Contains(args, flag)
 }
 
+// isStructuredOutput returns true if the args request any machine-readable
+// output mode.  This covers --json, -j, and --format json/sarif/markdown.
+// Used by main() to suppress human-oriented output (update notices, trailing
+// newlines) that would violate the structured-output contract.
+func isStructuredOutput(args []string) bool {
+	if hasFlag(args, "--json") || hasFlag(args, "-j") {
+		return true
+	}
+	for i, arg := range args {
+		if arg == "--format" && i+1 < len(args) {
+			switch args[i+1] {
+			case "json", "sarif", "markdown":
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // wantsHelp returns true if args contain --help or -h.
 func wantsHelp(args []string) bool {
 	return hasFlag(args, "--help") || hasFlag(args, "-h")

--- a/cmd/skillshare/json_output_test.go
+++ b/cmd/skillshare/json_output_test.go
@@ -49,6 +49,31 @@ func TestWriteJSONError(t *testing.T) {
 	}
 }
 
+func TestIsStructuredOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"--json", []string{"search", "foo", "--json"}, true},
+		{"-j short alias", []string{"list", "-j"}, true},
+		{"--format json", []string{"audit", "--format", "json"}, true},
+		{"--format sarif", []string{"audit", "--format", "sarif"}, true},
+		{"--format markdown", []string{"audit", "--format", "markdown"}, true},
+		{"--format text is not structured", []string{"audit", "--format", "text"}, false},
+		{"no flags", []string{"search", "foo"}, false},
+		{"empty args", []string{}, false},
+		{"--format without value", []string{"audit", "--format"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isStructuredOutput(tt.args); got != tt.want {
+				t.Errorf("isStructuredOutput(%v) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestWriteJSONErrorIsWrappedWithErrorsAs(t *testing.T) {
 	inner := writeJSONError(errors.New("wrapped sync failed"))
 	if inner == nil {

--- a/cmd/skillshare/main.go
+++ b/cmd/skillshare/main.go
@@ -111,14 +111,20 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Println()
+	// Structured-output contract: machine-readable modes (--json, -j,
+	// --format json/sarif/markdown) must produce only structured data on
+	// stdout and nothing on stderr.  Skip the trailing newline and update
+	// check entirely so machine consumers get a clean payload.
+	if !isStructuredOutput(args) {
+		fmt.Println()
 
-	// Check for updates (non-blocking, silent on errors)
-	// Skip for upgrade (just upgraded, old version in process) and doctor (has its own check)
-	if cmd != "upgrade" && cmd != "doctor" {
-		method := detectInstallMethod()
-		if result := versioncheck.Check(version, method); result != nil && result.UpdateAvailable {
-			ui.UpdateNotification(result.CurrentVersion, result.LatestVersion, result.InstallMethod.UpgradeCommand())
+		// Check for updates (non-blocking, silent on errors)
+		// Skip for upgrade (just upgraded, old version in process) and doctor (has its own check)
+		if cmd != "upgrade" && cmd != "doctor" {
+			method := detectInstallMethod()
+			if result := versioncheck.Check(version, method); result != nil && result.UpdateAvailable {
+				ui.UpdateNotification(result.CurrentVersion, result.LatestVersion, result.InstallMethod.UpgradeCommand())
+			}
 		}
 	}
 }

--- a/internal/ui/pterm.go
+++ b/internal/ui/pterm.go
@@ -547,12 +547,12 @@ func RenderInlineBar(done, total int) string {
 // or "skillshare upgrade").
 func UpdateNotification(currentVersion, latestVersion, upgradeCmd string) {
 	if !IsTTY() {
-		fmt.Printf("\n! Update available: %s -> %s\n", currentVersion, latestVersion)
-		fmt.Printf("  Run '%s' to update\n", upgradeCmd)
+		fmt.Fprintf(os.Stderr, "\n! Update available: %s -> %s\n", currentVersion, latestVersion)
+		fmt.Fprintf(os.Stderr, "  Run '%s' to update\n", upgradeCmd)
 		return
 	}
 
-	fmt.Println()
+	fmt.Fprintln(os.Stderr)
 	versionLine := fmt.Sprintf("  Version: %s -> %s", currentVersion, latestVersion)
 	runLine := fmt.Sprintf("  Run: %s", upgradeCmd)
 	w := DisplayWidth(versionLine)
@@ -560,10 +560,10 @@ func UpdateNotification(currentVersion, latestVersion, upgradeCmd string) {
 		w = rw
 	}
 
-	fmt.Println(pterm.Yellow("Update Available"))
-	fmt.Println(pterm.Yellow(strings.Repeat("─", w)))
-	fmt.Println(versionLine)
-	fmt.Println(runLine)
+	fmt.Fprintln(os.Stderr, pterm.Yellow("Update Available"))
+	fmt.Fprintln(os.Stderr, pterm.Yellow(strings.Repeat("─", w)))
+	fmt.Fprintln(os.Stderr, versionLine)
+	fmt.Fprintln(os.Stderr, runLine)
 }
 
 // SyncSummary prints a sync summary line.

--- a/internal/ui/pterm_update_test.go
+++ b/internal/ui/pterm_update_test.go
@@ -1,0 +1,47 @@
+package ui
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestUpdateNotification_WritesToStderr(t *testing.T) {
+	// Capture stderr
+	oldStderr := os.Stderr
+	rErr, wErr, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = wErr
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = wOut
+
+	UpdateNotification("1.0.0", "2.0.0", "skillshare upgrade")
+
+	wErr.Close()
+	wOut.Close()
+	os.Stderr = oldStderr
+	os.Stdout = oldStdout
+
+	var stderrBuf bytes.Buffer
+	io.Copy(&stderrBuf, rErr)
+
+	var stdoutBuf bytes.Buffer
+	io.Copy(&stdoutBuf, rOut)
+
+	if stdoutBuf.Len() > 0 {
+		t.Errorf("UpdateNotification must not write to stdout, got: %s", stdoutBuf.String())
+	}
+	if !strings.Contains(stderrBuf.String(), "1.0.0") || !strings.Contains(stderrBuf.String(), "2.0.0") {
+		t.Errorf("UpdateNotification should write version info to stderr, got: %s", stderrBuf.String())
+	}
+}

--- a/proposals/TEMPLATE.md
+++ b/proposals/TEMPLATE.md
@@ -1,0 +1,29 @@
+# Feature Proposal: [Title]
+
+## Problem
+
+What problem does this solve? Who is affected?
+
+## Proposed Solution
+
+Describe your approach at a high level. Include:
+
+- What changes are needed (CLI, UI, internal packages)
+- How it interacts with existing features
+- Any new dependencies
+
+## Alternatives Considered
+
+What other approaches did you consider? Why did you choose this one?
+
+## Scope
+
+Estimate the scope of changes:
+
+- [ ] Small (1-3 files, < 200 lines)
+- [ ] Medium (3-10 files, 200-500 lines)
+- [ ] Large (10+ files, 500+ lines)
+
+## Open Questions
+
+List anything you're unsure about or would like feedback on.

--- a/tests/integration/search_index_test.go
+++ b/tests/integration/search_index_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -173,5 +174,110 @@ func TestSearch_HubBare_FallbackToCommunity(t *testing.T) {
 	combined := result.Stdout + result.Stderr
 	if strings.Contains(combined, "not found; run") {
 		t.Errorf("bare --hub with no default should fallback to community hub, not label error")
+	}
+}
+
+// Regression test for https://github.com/runkids/skillshare/issues/129
+//
+// Build a non-dev binary with a low version and seed the version cache with a
+// "newer" release.  Without the fix, the update notice leaks into structured
+// output.  Each subtest exercises a different structured-output entry point
+// (--json, -j, --format json) and asserts that stdout is valid JSON and stderr
+// is empty — matching the repo's structured-output contract (audit_test.go:1242).
+func TestStructuredOutput_UpdateNoticeNotLeaked(t *testing.T) {
+	// Build a binary with version=1.0.0 so the update check actually runs
+	// (dev builds skip the check entirely).
+	projectRoot := findProjectRoot(t)
+	binPath := filepath.Join(t.TempDir(), "skillshare")
+	build := exec.Command("go", "build",
+		"-ldflags", "-X main.version=1.0.0",
+		"-o", binPath,
+		"./cmd/skillshare")
+	build.Dir = projectRoot
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build versioned binary: %v\n%s", err, out)
+	}
+
+	// seedCache creates a sandbox with a seeded version cache that makes
+	// the update check believe 9.9.9 is available.
+	seedCache := func(t *testing.T) *testutil.Sandbox {
+		t.Helper()
+		sb := testutil.NewSandbox(t)
+		sb.BinaryPath = binPath
+
+		cacheDir := filepath.Join(sb.Home, ".cache", "skillshare")
+		if err := os.MkdirAll(cacheDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		cache := `{"last_checked":"2099-01-01T00:00:00Z","latest_version":"9.9.9"}`
+		if err := os.WriteFile(filepath.Join(cacheDir, "version-check.json"), []byte(cache), 0644); err != nil {
+			t.Fatal(err)
+		}
+		return sb
+	}
+
+	// assertCleanStructuredOutput checks the structured-output contract.
+	assertCleanStructuredOutput := func(t *testing.T, result *testutil.Result) {
+		t.Helper()
+		result.AssertSuccess(t)
+		stdout := strings.TrimSpace(result.Stdout)
+		if !json.Valid([]byte(stdout)) {
+			t.Fatalf("stdout is not valid JSON:\n%s", result.Stdout)
+		}
+		if strings.TrimSpace(result.Stderr) != "" {
+			t.Fatalf("expected empty stderr, got:\n%s", result.Stderr)
+		}
+	}
+
+	t.Run("search --json", func(t *testing.T) {
+		sb := seedCache(t)
+		defer sb.Cleanup()
+		sb.WriteConfig(`source: ` + sb.SourcePath + "\ntargets: {}\n")
+		indexPath := writeIndexFile(t, sb.Home, []map[string]string{
+			{"name": "test-skill", "source": "owner/repo/path"},
+		})
+		result := sb.RunCLI("search", "test-skill", "--hub", indexPath, "--json")
+		assertCleanStructuredOutput(t, result)
+	})
+
+	t.Run("list -j", func(t *testing.T) {
+		sb := seedCache(t)
+		defer sb.Cleanup()
+		sb.CreateSkill("my-skill", map[string]string{
+			"SKILL.md": "---\nname: my-skill\n---\n# Content",
+		})
+		sb.WriteConfig(`source: ` + sb.SourcePath + "\ntargets: {}\n")
+		result := sb.RunCLI("list", "-j")
+		assertCleanStructuredOutput(t, result)
+	})
+
+	t.Run("audit --format json", func(t *testing.T) {
+		sb := seedCache(t)
+		defer sb.Cleanup()
+		sb.CreateSkill("safe-skill", map[string]string{
+			"SKILL.md": "---\nname: safe-skill\n---\n# Safe",
+		})
+		sb.WriteConfig(`source: ` + sb.SourcePath + "\ntargets: {}\n")
+		result := sb.RunCLI("audit", "--format", "json")
+		assertCleanStructuredOutput(t, result)
+	})
+}
+
+// findProjectRoot walks up from cwd until it finds go.mod.
+func findProjectRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find project root (go.mod)")
+		}
+		dir = parent
 	}
 }

--- a/website/src/pages/changelog.md
+++ b/website/src/pages/changelog.md
@@ -9,6 +9,12 @@ All notable changes to skillshare are documented here. For the full commit histo
 
 ---
 
+## [0.19.1] - 2026-04-13
+
+### Bug Fixes
+
+- **Structured output no longer corrupted by update notices** — `--json`, `-j`, and `--format json/sarif/markdown` modes could emit a trailing human-readable update notification into stdout, producing invalid JSON for downstream consumers. The update check is now skipped entirely in structured-output modes, and the notification itself writes to stderr as a safety net. Refs: #129
+
 ## [0.19.0] - 2026-04-11
 
 ### New Features


### PR DESCRIPTION
### Bug Fixes

- **Structured output no longer corrupted by update notices** — `--json`, `-j`, and `--format json/sarif/markdown` modes could emit a trailing human-readable update notification into stdout, producing invalid JSON for downstream consumers. The update check is now skipped entirely in structured-output modes, and the notification itself writes to stderr as a safety net. Refs: #129