### PR TITLE
fix(install): do not remove local source dirs in CleanupDiscovery

### DIFF
--- a/internal/install/install_discovery.go
+++ b/internal/install/install_discovery.go
@@ -435,12 +435,18 @@ func discoverFromGitSubdirImpl(source *Source) (*DiscoveryResult, error) {
 	return discoverFromGitSubdirWithProgressImpl(source, nil)
 }
 
-// CleanupDiscovery removes the temporary directory from discovery
+// CleanupDiscovery removes the temporary directory created for git-based
+// discovery. Local-path discovery reuses the user's directory as RepoPath;
+// that path is never removed here.
 
 func cleanupDiscoveryImpl(result *DiscoveryResult) {
-	if result != nil && result.RepoPath != "" {
-		os.RemoveAll(result.RepoPath)
+	if result == nil || result.RepoPath == "" {
+		return
 	}
+	if result.Source != nil && result.Source.Type == SourceTypeLocalPath {
+		return
+	}
+	os.RemoveAll(result.RepoPath)
 }
 
 // InstallFromDiscovery installs a skill from a discovered repository

--- a/internal/install/install_discovery.go
+++ b/internal/install/install_discovery.go
@@ -436,14 +436,16 @@ func discoverFromGitSubdirImpl(source *Source) (*DiscoveryResult, error) {
 }
 
 // CleanupDiscovery removes the temporary directory created for git-based
-// discovery. Local-path discovery reuses the user's directory as RepoPath;
-// that path is never removed here.
+// discovery (clone under RepoPath). It only runs when Source is known to be
+// a git remote; local paths, missing source metadata, and other types are
+// skipped so RepoPath is never treated as disposable unless it came from a
+// git clone.
 
 func cleanupDiscoveryImpl(result *DiscoveryResult) {
-	if result == nil || result.RepoPath == "" {
+	if result == nil || result.RepoPath == "" || result.Source == nil {
 		return
 	}
-	if result.Source != nil && result.Source.Type == SourceTypeLocalPath {
+	if !result.Source.IsGit() {
 		return
 	}
 	os.RemoveAll(result.RepoPath)

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -150,6 +150,18 @@ func TestCleanupDiscovery_PreservesLocalSource(t *testing.T) {
 	}
 }
 
+func TestCleanupDiscovery_SkipsWhenSourceNil(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "keep.txt")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	CleanupDiscovery(&DiscoveryResult{RepoPath: dir, Source: nil})
+	if _, err := os.Stat(file); err != nil {
+		t.Fatalf("directory was removed when Source was nil: %v", err)
+	}
+}
+
 func TestDiscoverSkills_ChildrenOnly(t *testing.T) {
 	// Setup: orchestrator repo with no root SKILL.md, only children
 	repoPath := t.TempDir()

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -121,6 +121,35 @@ func TestDiscoverLocal_ExplicitSkillTarget_ReturnsOnlyRootSkill(t *testing.T) {
 	}
 }
 
+// Regression: UI discover endpoint defers CleanupDiscovery; for local sources
+// RepoPath is the user's directory and must not be removed.
+func TestCleanupDiscovery_PreservesLocalSource(t *testing.T) {
+	repoPath := t.TempDir()
+	skillFile := filepath.Join(repoPath, "SKILL.md")
+	if err := os.WriteFile(skillFile, []byte("---\nname: keep-me\n---\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	discovery, err := DiscoverLocal(&Source{
+		Type: SourceTypeLocalPath,
+		Raw:  repoPath,
+		Path: repoPath,
+		Name: filepath.Base(repoPath),
+	})
+	if err != nil {
+		t.Fatalf("DiscoverLocal: %v", err)
+	}
+	if discovery.RepoPath != repoPath {
+		t.Fatalf("RepoPath = %q, want %q", discovery.RepoPath, repoPath)
+	}
+
+	CleanupDiscovery(discovery)
+
+	if _, err := os.Stat(skillFile); err != nil {
+		t.Fatalf("local source was removed after CleanupDiscovery: %v", err)
+	}
+}
+
 func TestDiscoverSkills_ChildrenOnly(t *testing.T) {
 	// Setup: orchestrator repo with no root SKILL.md, only children
 	repoPath := t.TempDir()


### PR DESCRIPTION
Local discovery sets RepoPath to the user's directory; the UI discover handler defers CleanupDiscovery and was deleting that tree after the response. Skip RemoveAll for SourceTypeLocalPath so UI local installs match CLI behavior.

Adds TestCleanupDiscovery_PreservesLocalSource regression coverage.


<!-- Thanks for contributing! Please read CONTRIBUTING.md before submitting. -->

## Type

- [x] Bug fix
- [ ] Small improvement (docs, typo, minor refactor)
- [ ] Feature proposal (`proposals/` only — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Linked Issue

[<!-- Recommended for bug fixes. Required for proposals. -->](https://github.com/runkids/skillshare/issues/139)

Closes #

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Tests included and passing (`make check`) — for code changes
- [x] No unrelated changes in the diff
- [x] Scope is focused — one concern per PR
