### PR TITLE
Infer targets from host-specific skill paths

### DIFF
--- a/internal/sync/discover_test.go
+++ b/internal/sync/discover_test.go
@@ -136,14 +136,16 @@ func TestDiscoverSourceSkills_InfersTargetsFromHostPaths(t *testing.T) {
 	writeSkillMD(t, filepath.Join(src, ".cursor", "skills", "gstack-browse"), "---\nname: gstack-browse\n---\n# Cursor")
 	writeSkillMD(t, filepath.Join(src, "openclaw", "skills", "gstack-openclaw-investigate"), "---\nname: gstack-openclaw-investigate\n---\n# Openclaw")
 	writeSkillMD(t, filepath.Join(src, ".factory", "skills", "gstack-benchmark"), "---\nname: gstack-benchmark\n---\n# Factory")
+	writeSkillMD(t, filepath.Join(src, ".skills", "letta-skill"), "---\nname: letta-skill\n---\n# Letta")
+	writeSkillMD(t, filepath.Join(src, ".agents", "skills", "universal-skill"), "---\nname: universal-skill\n---\n# Universal")
 	writeSkillMD(t, filepath.Join(src, "shared", "generic"), "---\nname: generic\n---\n# Generic")
 
 	skills, err := DiscoverSourceSkills(src)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(skills) != 4 {
-		t.Fatalf("expected 4 skills, got %d", len(skills))
+	if len(skills) != 6 {
+		t.Fatalf("expected 6 skills, got %d", len(skills))
 	}
 
 	byRel := make(map[string]DiscoveredSkill)
@@ -173,6 +175,22 @@ func TestDiscoverSourceSkills_InfersTargetsFromHostPaths(t *testing.T) {
 	}
 	if len(factorySkill.Targets) != 1 || factorySkill.Targets[0] != "droid" {
 		t.Errorf("expected .factory host skill to target [droid], got %v", factorySkill.Targets)
+	}
+
+	lettaSkill := byRel[".skills/letta-skill"]
+	if lettaSkill.RelPath == "" {
+		t.Fatalf("missing .skills/letta-skill")
+	}
+	if len(lettaSkill.Targets) != 1 || lettaSkill.Targets[0] != "letta" {
+		t.Errorf("expected .skills host skill to target [letta], got %v", lettaSkill.Targets)
+	}
+
+	universalSkill := byRel[".agents/skills/universal-skill"]
+	if universalSkill.RelPath == "" {
+		t.Fatalf("missing .agents/skills/universal-skill")
+	}
+	if len(universalSkill.Targets) != 1 || universalSkill.Targets[0] != "universal" {
+		t.Errorf("expected .agents host skill to target [universal], got %v", universalSkill.Targets)
 	}
 
 	genericSkill := byRel["shared/generic"]

--- a/internal/sync/discover_test.go
+++ b/internal/sync/discover_test.go
@@ -130,6 +130,60 @@ func TestDiscoverSourceSkills_ParsesTargets(t *testing.T) {
 	}
 }
 
+func TestDiscoverSourceSkills_InfersTargetsFromHostPaths(t *testing.T) {
+	src := t.TempDir()
+
+	writeSkillMD(t, filepath.Join(src, ".cursor", "skills", "gstack-browse"), "---\nname: gstack-browse\n---\n# Cursor")
+	writeSkillMD(t, filepath.Join(src, "openclaw", "skills", "gstack-openclaw-investigate"), "---\nname: gstack-openclaw-investigate\n---\n# Openclaw")
+	writeSkillMD(t, filepath.Join(src, ".factory", "skills", "gstack-benchmark"), "---\nname: gstack-benchmark\n---\n# Factory")
+	writeSkillMD(t, filepath.Join(src, "shared", "generic"), "---\nname: generic\n---\n# Generic")
+
+	skills, err := DiscoverSourceSkills(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skills) != 4 {
+		t.Fatalf("expected 4 skills, got %d", len(skills))
+	}
+
+	byRel := make(map[string]DiscoveredSkill)
+	for _, s := range skills {
+		byRel[s.RelPath] = s
+	}
+
+	cursorSkill := byRel[".cursor/skills/gstack-browse"]
+	if cursorSkill.RelPath == "" {
+		t.Fatalf("missing .cursor/skills/gstack-browse")
+	}
+	if len(cursorSkill.Targets) != 1 || cursorSkill.Targets[0] != "cursor" {
+		t.Errorf("expected cursor host skill to target [cursor], got %v", cursorSkill.Targets)
+	}
+
+	openclawSkill := byRel["openclaw/skills/gstack-openclaw-investigate"]
+	if openclawSkill.RelPath == "" {
+		t.Fatalf("missing openclaw/skills/gstack-openclaw-investigate")
+	}
+	if len(openclawSkill.Targets) != 1 || openclawSkill.Targets[0] != "openclaw" {
+		t.Errorf("expected openclaw host skill to target [openclaw], got %v", openclawSkill.Targets)
+	}
+
+	factorySkill := byRel[".factory/skills/gstack-benchmark"]
+	if factorySkill.RelPath == "" {
+		t.Fatalf("missing .factory/skills/gstack-benchmark")
+	}
+	if len(factorySkill.Targets) != 1 || factorySkill.Targets[0] != "droid" {
+		t.Errorf("expected .factory host skill to target [droid], got %v", factorySkill.Targets)
+	}
+
+	genericSkill := byRel["shared/generic"]
+	if genericSkill.RelPath == "" {
+		t.Fatalf("missing shared/generic")
+	}
+	if genericSkill.Targets != nil {
+		t.Errorf("expected generic skill targets to be nil, got %v", genericSkill.Targets)
+	}
+}
+
 func TestDiscoverSourceSkills_EmptyDir(t *testing.T) {
 	src := t.TempDir()
 
@@ -169,6 +223,25 @@ func TestDiscoverSourceSkillsLite_SkipsTargetsParsing(t *testing.T) {
 		t.Fatalf("expected 1 skill, got %d", len(skills))
 	}
 	// Lite version should NOT parse targets
+	if skills[0].Targets != nil {
+		t.Errorf("expected Targets to be nil in Lite mode, got %v", skills[0].Targets)
+	}
+	if len(repos) != 0 {
+		t.Errorf("expected 0 tracked repos, got %d", len(repos))
+	}
+}
+
+func TestDiscoverSourceSkillsLite_DoesNotInferTargetsFromPath(t *testing.T) {
+	src := t.TempDir()
+	writeSkillMD(t, filepath.Join(src, ".cursor", "skills", "gstack-browse"), "---\nname: gstack-browse\n---\n# Cursor")
+
+	skills, repos, err := DiscoverSourceSkillsLite(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(skills))
+	}
 	if skills[0].Targets != nil {
 		t.Errorf("expected Targets to be nil in Lite mode, got %v", skills[0].Targets)
 	}

--- a/internal/sync/discover_walk.go
+++ b/internal/sync/discover_walk.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 
@@ -24,7 +25,14 @@ type discoverOptions struct {
 var (
 	knownTargetNameSet     map[string]bool
 	knownTargetNameSetOnce sync.Once
+	projectTargetPaths     []projectTargetPath
+	projectTargetPathsOnce sync.Once
 )
+
+type projectTargetPath struct {
+	name string
+	path string
+}
 
 func getKnownTargetNameSet() map[string]bool {
 	knownTargetNameSetOnce.Do(func() {
@@ -37,16 +45,39 @@ func getKnownTargetNameSet() map[string]bool {
 	return knownTargetNameSet
 }
 
-func inferSkillTargetsFromRelPath(relPath string) []string {
-	parts := strings.Split(relPath, "/")
-	if len(parts) < 3 || parts[1] != "skills" {
-		return nil
-	}
+func getProjectTargetPaths() []projectTargetPath {
+	projectTargetPathsOnce.Do(func() {
+		groupedTargets := config.GroupedProjectTargets()
+		projectTargetPaths = make([]projectTargetPath, 0, len(groupedTargets))
+		for _, target := range groupedTargets {
+			if target.Name == "" || target.Path == "" {
+				continue
+			}
+			projectTargetPaths = append(projectTargetPaths, projectTargetPath{
+				name: target.Name,
+				path: filepath.ToSlash(target.Path),
+			})
+		}
+		sort.Slice(projectTargetPaths, func(i, j int) bool {
+			if projectTargetPaths[i].path == projectTargetPaths[j].path {
+				return projectTargetPaths[i].name < projectTargetPaths[j].name
+			}
+			return projectTargetPaths[i].path < projectTargetPaths[j].path
+		})
+	})
+	return projectTargetPaths
+}
 
+func inferSkillTargetsFromRelPath(relPath string) []string {
 	// Prefer explicit project paths from known targets (e.g. ".factory/skills").
 	targets := inferTargetsFromProjectPaths(relPath)
 	if len(targets) > 0 {
 		return targets
+	}
+
+	parts := strings.Split(relPath, "/")
+	if len(parts) < 3 || parts[1] != "skills" {
+		return nil
 	}
 
 	// Fallback to top-level host-style paths that match known target names
@@ -64,17 +95,10 @@ func inferSkillTargetsFromRelPath(relPath string) []string {
 
 func inferTargetsFromProjectPaths(relPath string) []string {
 	targets := make([]string, 0, 2)
-	seen := make(map[string]bool)
 
-	for targetName, pathCfg := range config.ProjectTargets() {
-		if targetName == "" || pathCfg.Path == "" {
-			continue
-		}
-
-		targetPath := filepath.ToSlash(pathCfg.Path)
-		if matchesHostSkillPath(relPath, targetName, targetPath) && !seen[targetName] {
-			seen[targetName] = true
-			targets = append(targets, targetName)
+	for _, target := range getProjectTargetPaths() {
+		if matchesHostSkillPath(relPath, target.name, target.path) {
+			targets = append(targets, target.name)
 		}
 	}
 

--- a/internal/sync/discover_walk.go
+++ b/internal/sync/discover_walk.go
@@ -5,7 +5,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
+	"skillshare/internal/config"
 	"skillshare/internal/skillignore"
 	"skillshare/internal/utils"
 )
@@ -17,6 +19,80 @@ type discoverOptions struct {
 	collectTracked   bool // collect tracked repo paths (for Lite mode)
 	collectContext   bool // compute DescChars/BodyChars during walk (for analyze)
 	includeIgnored   bool // include ignored skills in results with Disabled=true
+}
+
+var (
+	knownTargetNameSet     map[string]bool
+	knownTargetNameSetOnce sync.Once
+)
+
+func getKnownTargetNameSet() map[string]bool {
+	knownTargetNameSetOnce.Do(func() {
+		targetNames := config.KnownTargetNames()
+		knownTargetNameSet = make(map[string]bool, len(targetNames))
+		for _, name := range targetNames {
+			knownTargetNameSet[name] = true
+		}
+	})
+	return knownTargetNameSet
+}
+
+func inferSkillTargetsFromRelPath(relPath string) []string {
+	parts := strings.Split(relPath, "/")
+	if len(parts) < 3 || parts[1] != "skills" {
+		return nil
+	}
+
+	// Prefer explicit project paths from known targets (e.g. ".factory/skills").
+	targets := inferTargetsFromProjectPaths(relPath)
+	if len(targets) > 0 {
+		return targets
+	}
+
+	// Fallback to top-level host-style paths that match known target names
+	// (e.g. "openclaw/skills/*" for openclaw project path "skills").
+	host := strings.TrimPrefix(parts[0], ".")
+	if host == "" {
+		return nil
+	}
+	if getKnownTargetNameSet()[host] {
+		return []string{host}
+	}
+
+	return nil
+}
+
+func inferTargetsFromProjectPaths(relPath string) []string {
+	targets := make([]string, 0, 2)
+	seen := make(map[string]bool)
+
+	for targetName, pathCfg := range config.ProjectTargets() {
+		if targetName == "" || pathCfg.Path == "" {
+			continue
+		}
+
+		targetPath := filepath.ToSlash(pathCfg.Path)
+		if matchesHostSkillPath(relPath, targetName, targetPath) && !seen[targetName] {
+			seen[targetName] = true
+			targets = append(targets, targetName)
+		}
+	}
+
+	return targets
+}
+
+func matchesHostSkillPath(relPath, targetName, targetPath string) bool {
+	switch {
+	case targetPath == "skills":
+		parts := strings.Split(relPath, "/")
+		return len(parts) >= 2 && parts[1] == "skills" && strings.TrimPrefix(parts[0], ".") == targetName
+	case relPath == targetPath:
+		return false
+	case strings.HasPrefix(relPath, targetPath+"/"):
+		return true
+	default:
+		return false
+	}
 }
 
 // discoverSourceSkillsInternal is the shared walk implementation used by all
@@ -152,6 +228,7 @@ func discoverSourceSkillsInternal(sourcePath string, opts discoverOptions) ([]Di
 						RelPath:    relPath,
 						FlatName:   utils.PathToFlatName(relPath),
 						IsInRepo:   inRepo,
+						Targets:    inferSkillTargetsFromRelPath(relPath),
 						Disabled:   true,
 					})
 				}
@@ -174,6 +251,7 @@ func discoverSourceSkillsInternal(sourcePath string, opts discoverOptions) ([]Di
 						RelPath:    relPath,
 						FlatName:   utils.PathToFlatName(relPath),
 						IsInRepo:   true,
+						Targets:    inferSkillTargetsFromRelPath(relPath),
 						Disabled:   true,
 					})
 				}
@@ -207,6 +285,10 @@ func discoverSourceSkillsInternal(sourcePath string, opts discoverOptions) ([]Di
 				}
 			} else if opts.parseFrontmatter {
 				targets = utils.ParseFrontmatterList(skillFile, "targets")
+			}
+
+			if len(targets) == 0 && (opts.parseFrontmatter || opts.collectContext) {
+				targets = inferSkillTargetsFromRelPath(relPath)
 			}
 
 			// Use original sourcePath (not walkRoot) so SourcePath preserves

--- a/tests/integration/skill_targets_test.go
+++ b/tests/integration/skill_targets_test.go
@@ -51,6 +51,54 @@ targets:
 	}
 }
 
+func TestSkillTargets_InfersTargetsFromHostPaths(t *testing.T) {
+	sb := testutil.NewSandbox(t)
+	defer sb.Cleanup()
+
+	sb.CreateNestedSkill(".cursor/skills/gstack-browse", map[string]string{
+		"SKILL.md": "---\nname: gstack-browse\n---\n# Cursor host skill",
+	})
+	sb.CreateNestedSkill(".factory/skills/gstack-benchmark", map[string]string{
+		"SKILL.md": "---\nname: gstack-benchmark\n---\n# Factory host skill",
+	})
+	sb.CreateSkill("generic", map[string]string{
+		"SKILL.md": "---\nname: generic\n---\n# Generic",
+	})
+
+	cursorPath := sb.CreateTarget("cursor")
+	droidPath := sb.CreateTarget("droid")
+
+	sb.WriteConfig(`source: ` + sb.SourcePath + `
+targets:
+  cursor:
+    path: ` + cursorPath + `
+  droid:
+    path: ` + droidPath + `
+`)
+
+	sb.RunCLI("sync").AssertSuccess(t)
+
+	if !sb.IsSymlink(filepath.Join(cursorPath, ".cursor__skills__gstack-browse")) {
+		t.Error("cursor host skill should be synced to cursor target")
+	}
+	if sb.FileExists(filepath.Join(cursorPath, ".factory__skills__gstack-benchmark")) {
+		t.Error("factory host skill should NOT be synced to cursor target")
+	}
+	if !sb.IsSymlink(filepath.Join(cursorPath, "generic")) {
+		t.Error("generic skill should still sync to cursor target")
+	}
+
+	if !sb.IsSymlink(filepath.Join(droidPath, ".factory__skills__gstack-benchmark")) {
+		t.Error("factory host skill should be synced to droid target")
+	}
+	if sb.FileExists(filepath.Join(droidPath, ".cursor__skills__gstack-browse")) {
+		t.Error("cursor host skill should NOT be synced to droid target")
+	}
+	if !sb.IsSymlink(filepath.Join(droidPath, "generic")) {
+		t.Error("generic skill should still sync to droid target")
+	}
+}
+
 func TestSkillTargets_CrossModeMatching(t *testing.T) {
 	sb := testutil.NewSandbox(t)
 	defer sb.Cleanup()


### PR DESCRIPTION
## Summary

Fixes target filtering for multi-host skill repos that package host-specific skill trees such as:

- `.cursor/skills/...`
- `.factory/skills/...`
- `openclaw/skills/...`
- `.agents/skills/...`

When a nested `SKILL.md` omits `targets:` frontmatter, discovery currently leaves `Targets` as `nil`. During sync, `nil` means "sync to every target", so a host-specific skill can be copied into unrelated tools. This makes the same logical skill appear multiple times in tools that index nested `SKILL.md` files, especially with gstack-style repos.

## Changes

- Infer targets from known project skill paths during full discovery.
- Keep generic skills unchanged: skills outside host-specific paths still keep `Targets == nil` and sync everywhere.
- Keep `DiscoverSourceSkillsLite` behavior unchanged, because lite discovery is used by commands that do not need target filtering.
- Addressed bot review feedback:
  - project-path matching now runs before the `*/skills/*` fallback, so paths such as `.skills/<skill>` are covered;
  - project target paths are cached and sorted once instead of rebuilding the map per discovered skill;
  - shared project paths use `config.GroupedProjectTargets()` so inference returns the canonical grouped target, e.g. `.agents/skills` -> `universal`.

## Linked Issue

Fixes #145

## Tests

```bash
env GOCACHE=/Users/larry_1/Opensource/skillshare/.tmp/go-build go test ./internal/sync
env GOCACHE=/Users/larry_1/Opensource/skillshare/.tmp/go-build go test ./internal/...
env GOCACHE=/Users/larry_1/Opensource/skillshare/.tmp/go-build go build -o bin/skillshare ./cmd/skillshare
env GOCACHE=/Users/larry_1/Opensource/skillshare/.tmp/go-build SKILLSHARE_TEST_BINARY=/Users/larry_1/Opensource/skillshare/bin/skillshare go test ./tests/integration -run TestSkillTargets
```

Current `gh pr checks` output only reports the Vercel deployment authorization failure for the fork PR. The local checks above pass.
