### PR TITLE
Fix install command not works with http protocol

### DIFF
--- a/internal/install/source.go
+++ b/internal/install/source.go
@@ -56,7 +56,7 @@ var githubPattern = regexp.MustCompile(`^(?:https?://)?github\.com/([^/]+)/([^/]
 var gitSSHPattern = regexp.MustCompile(`^git@([^:]+):([^/]+)/(.+?)(?:\.git)?(?://(.+))?$`)
 
 // Git HTTPS pattern: https://host/path (flexible path for GitLab subgroups)
-var gitHTTPSPattern = regexp.MustCompile(`^https?://([^/]+)/(.+)$`)
+var gitHTTPSPattern = regexp.MustCompile(`^(https?)://([^/]+)/(.+)$`)
 
 // File URL pattern: file:///path/to/repo[//subdir]
 var fileURLPattern = regexp.MustCompile(`^file://(.+?)(?://(.+))?$`)
@@ -373,11 +373,12 @@ func parseAzureSSH(org, project, repo, subdir string, source *Source) (*Source, 
 }
 
 func parseGitHTTPS(matches []string, source *Source, opts ParseOptions) (*Source, error) {
-	// matches: [full, host, path]
-	host := matches[1]
+	// matches: [full, schema, host, path]
+	schema := matches[1]
+	host := matches[2]
 	// Trim trailing slashes first, then /. — order matters:
 	// "foo/.//" → "foo/." → "foo"
-	path := strings.TrimRight(matches[2], "/")
+	path := strings.TrimRight(matches[3], "/")
 	path = strings.TrimSuffix(path, "/.")
 
 	var repoPath, subdir string
@@ -429,7 +430,7 @@ func parseGitHTTPS(matches []string, source *Source, opts ParseOptions) (*Source
 	}
 
 	source.Type = SourceTypeGitHTTPS
-	source.CloneURL = fmt.Sprintf("https://%s/%s.git", host, repoPath)
+	source.CloneURL = fmt.Sprintf("%s://%s/%s.git", schema, host, repoPath)
 
 	if subdir != "" {
 		source.Subdir = subdir


### PR DESCRIPTION
<!-- Thanks for contributing! Please read CONTRIBUTING.md before submitting. -->

# Fix `skillshare install` for plain HTTP Git repository URLs

## Type

- [x] Bug fix
- [ ] Small improvement (docs, typo, minor refactor)
- [ ] Feature proposal (`proposals/` only — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Summary

`skillshare install` should preserve the protocol from generic Git HTTP(S) repository URLs. Before the fix, the generic Git URL parser accepted both `http://` and `https://` inputs, but always rebuilt the clone URL with `https://`. This made installs from repositories that are only available over plain HTTP fail.

## Problem

The generic Git HTTPS parser in `internal/install/source.go` matched URLs with either `http://` or `https://`, but the regular expression did not capture the scheme. `parseGitHTTPS` therefore only received the host and path, then constructed `source.CloneURL` with a hard-coded `https://` prefix.

That means an input such as:

```text
http://git.example.local/group/skills
```

was parsed into a clone URL like:

```text
https://git.example.local/group/skills.git
```

For internal Git servers, lab environments, or self-hosted repositories that intentionally expose only HTTP, this causes install failures even though the user supplied a valid HTTP URL.

## Expected Behavior

When a user installs from a generic Git URL:

```text
skillshare install http://git.example.local/group/skills
```

the parsed clone URL should preserve the original scheme:

```text
http://git.example.local/group/skills.git
```

Existing `https://` inputs should continue to produce `https://` clone URLs.

## Proposed Fix

Capture the URL scheme in `gitHTTPSPattern` and pass it through `parseGitHTTPS` when constructing `source.CloneURL`.

The latest commit implements this by:

- changing `gitHTTPSPattern` from `^https?://([^/]+)/(.+)$` to `^(https?)://([^/]+)/(.+)$`
- updating `parseGitHTTPS` to read `schema`, `host`, and `path` from the new capture groups
- constructing `source.CloneURL` with `fmt.Sprintf("%s://%s/%s.git", schema, host, repoPath)`

## Scope

This is a small bug fix in `internal/install/source.go`. It does not change GitHub shorthand parsing, SSH parsing, Azure DevOps parsing, local path parsing, or subdirectory handling.
