### PR TITLE
Document TweetClaw skill install example

### DIFF
--- a/website/docs/reference/commands/install.md
+++ b/website/docs/reference/commands/install.md
@@ -30,6 +30,9 @@ flowchart TD
 # From GitHub (shorthand)
 skillshare install anthropics/skills/skills/pdf
 
+# OpenClaw skill from a nested GitHub path
+skillshare install Xquik-dev/tweetclaw/skills/tweetclaw --track
+
 # Browse available skills in a repo
 skillshare install anthropics/skills
 
@@ -160,6 +163,9 @@ Provide the full path to install immediately:
 skillshare install anthropics/skills/skills/pdf
 skillshare install google-gemini/gemini-cli/packages/core/src/skills/builtin/skill-creator
 
+# OpenClaw X/Twitter automation skill
+skillshare install Xquik-dev/tweetclaw/skills/tweetclaw --track
+
 # Fuzzy subdirectory — if exact path doesn't exist, matches by skill name
 skillshare install runkids/my-skills/vue-best-practices
 
@@ -180,6 +186,8 @@ skillshare install /absolute/path/to/skill
 :::tip Fuzzy subdirectory resolution
 When specifying a subdirectory path like `owner/repo/skill-name`, if the exact path doesn't exist in the repo, skillshare scans all `SKILL.md` files and matches by directory basename. If multiple skills share the same name, an ambiguity error is shown with full paths so you can specify the exact one.
 :::
+
+For example, `Xquik-dev/tweetclaw/skills/tweetclaw` installs TweetClaw's OpenClaw skill for search tweets, search tweet replies, post tweets, post tweet replies, follower export, user lookup, media workflows, monitor tweets, webhooks, and giveaway draws from the TweetClaw repository while leaving the package and plugin files outside the skill path.
 
 ## Install from Config (No Arguments)
 

--- a/website/docs/reference/commands/install.md
+++ b/website/docs/reference/commands/install.md
@@ -187,7 +187,7 @@ skillshare install /absolute/path/to/skill
 When specifying a subdirectory path like `owner/repo/skill-name`, if the exact path doesn't exist in the repo, skillshare scans all `SKILL.md` files and matches by directory basename. If multiple skills share the same name, an ambiguity error is shown with full paths so you can specify the exact one.
 :::
 
-For example, `Xquik-dev/tweetclaw/skills/tweetclaw` installs TweetClaw's OpenClaw skill for search tweets, search tweet replies, post tweets, post tweet replies, follower export, user lookup, media workflows, monitor tweets, webhooks, and giveaway draws from the TweetClaw repository while leaving the package and plugin files outside the skill path.
+For example, `Xquik-dev/tweetclaw/skills/tweetclaw` installs the TweetClaw OpenClaw skill from a nested path. Package and plugin files elsewhere in the repository stay outside the installed skill.
 
 ## Install from Config (No Arguments)
 


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [x] Small improvement (docs, typo, minor refactor)
- [ ] Feature proposal (`proposals/` only - see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Linked Issue

No issue. This is a small docs-only install example.

## Summary

- Add TweetClaw as a concrete OpenClaw nested-path install example.
- Show `skillshare install Xquik-dev/tweetclaw/skills/tweetclaw --track` in the install command docs.
- Explain why the nested path installs only the `tweetclaw` skill and leaves package/plugin files outside the skill path.

## Validation

- `git diff --check`
- Added-line banned dash scan
- Added-line sensitive-value scan
- Isolated temp config install of `Xquik-dev/tweetclaw/skills/tweetclaw`
- Isolated temp config install of `Xquik-dev/tweetclaw/skills/tweetclaw --track`
- `npm ci` in `website/`
- `npm run build` in `website/`

Note: `npm ci` reported 42 existing vulnerabilities in the website dependency tree, and the Docusaurus build emitted an existing webpack warning from `vscode-languageserver-types`. This PR only edits one docs markdown file.
