### PR TITLE
feat(config): opt-in preserve_tilde_on_save for dotfiles-friendly path serialization

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -265,6 +265,12 @@ type Config struct {
 	GitLabHosts   []string                `yaml:"gitlab_hosts,omitempty"`
 	AzureHosts    []string                `yaml:"azure_hosts,omitempty"`
 
+	// PreserveTildeOnSave folds $HOME prefixes back to ~ when serializing the
+	// config to YAML. Useful when the config is shared via dotfiles across
+	// machines or users. The in-memory config is unaffected; Load() still
+	// expands ~ as usual.
+	PreserveTildeOnSave bool `yaml:"preserve_tilde_on_save,omitempty"`
+
 	// RegistryDir is the resolved directory for registry.yaml (cached SourceRoot result).
 	// Set during Load(), not serialized to YAML.
 	RegistryDir string `yaml:"-"`
@@ -507,7 +513,17 @@ func (c *Config) Save() error {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
-	data, err := marshalYAML(c)
+	// fork patch: fold $HOME prefixes back to ~ so serialized paths are
+	// machine-agnostic (dotfiles-friendly). Opt-in via preserve_tilde_on_save.
+	// The in-memory config is left untouched; we marshal a shallow copy with
+	// folded path fields.
+	var payload *Config
+	if c.PreserveTildeOnSave {
+		payload = c.cloneForSave()
+	} else {
+		payload = c
+	}
+	data, err := marshalYAML(payload)
 	if err != nil {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
@@ -519,6 +535,63 @@ func (c *Config) Save() error {
 	}
 
 	return nil
+}
+
+// cloneForSave returns a shallow copy of c with all path fields folded back to
+// ~ form via utils.FoldHomePathWith. Slices and maps that contain path fields
+// are re-allocated to avoid mutating the live config. The user home directory
+// is resolved once and passed to FoldHomePathWith to avoid repeated syscalls.
+//
+// Keep this in sync with the expandPath() calls in Load().
+func (c *Config) cloneForSave() *Config {
+	out := *c
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		// Cannot fold without a home directory; serialize as-is.
+		return &out
+	}
+
+	fold := func(p string) string { return utils.FoldHomePathWith(p, home) }
+
+	out.Source = fold(out.Source)
+	out.AgentsSource = fold(out.AgentsSource)
+	out.ExtrasSource = fold(out.ExtrasSource)
+
+	if len(c.Targets) > 0 {
+		out.Targets = make(map[string]TargetConfig, len(c.Targets))
+		for name, tc := range c.Targets {
+			tc.Path = fold(tc.Path)
+			if tc.Skills != nil {
+				skills := *tc.Skills
+				skills.Path = fold(skills.Path)
+				tc.Skills = &skills
+			}
+			if tc.Agents != nil {
+				agents := *tc.Agents
+				agents.Path = fold(agents.Path)
+				tc.Agents = &agents
+			}
+			out.Targets[name] = tc
+		}
+	}
+
+	if len(c.Extras) > 0 {
+		out.Extras = make([]ExtraConfig, len(c.Extras))
+		for i, extra := range c.Extras {
+			extra.Source = fold(extra.Source)
+			if len(extra.Targets) > 0 {
+				targets := make([]ExtraTargetConfig, len(extra.Targets))
+				for j, et := range extra.Targets {
+					et.Path = fold(et.Path)
+					targets[j] = et
+				}
+				extra.Targets = targets
+			}
+			out.Extras[i] = extra
+		}
+	}
+
+	return &out
 }
 
 // ExpandPath expands ~ to home directory.

--- a/internal/config/config_tilde_fold_test.go
+++ b/internal/config/config_tilde_fold_test.go
@@ -1,0 +1,141 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fork patch tests: preserve_tilde_on_save opt-in behavior.
+
+func TestSave_DefaultDoesNotFoldTilde(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	t.Setenv("SKILLSHARE_CONFIG", cfgPath)
+
+	home, _ := os.UserHomeDir()
+	cfg := &Config{
+		Source: filepath.Join(home, "dotfiles", "skills"),
+		Targets: map[string]TargetConfig{
+			"claude": {Skills: &ResourceTargetConfig{Path: filepath.Join(home, ".claude", "skills")}},
+		},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	if !strings.Contains(got, home) {
+		t.Errorf("default Save should keep absolute paths; got:\n%s", got)
+	}
+	if strings.Contains(got, "~") && !strings.Contains(got, "~ ") {
+		// allow incidental ~ chars in comments; flag any ~/ path style
+		if strings.Contains(got, "~/") {
+			t.Errorf("default Save unexpectedly folded to ~; got:\n%s", got)
+		}
+	}
+}
+
+func TestSave_PreserveTildeOnSave_FoldsHomePaths(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	t.Setenv("SKILLSHARE_CONFIG", cfgPath)
+
+	home, _ := os.UserHomeDir()
+	cfg := &Config{
+		Source:              filepath.Join(home, "dotfiles", "skills"),
+		ExtrasSource:        filepath.Join(home, "my-extras"),
+		PreserveTildeOnSave: true,
+		Targets: map[string]TargetConfig{
+			"claude": {Skills: &ResourceTargetConfig{Path: filepath.Join(home, ".claude", "skills")}},
+			"cursor": {Skills: &ResourceTargetConfig{Path: filepath.Join(home, ".cursor", "skills")}},
+			// Non-home absolute path must NOT be folded
+			"weird": {Skills: &ResourceTargetConfig{Path: "/opt/weird/skills"}},
+		},
+		Extras: []ExtraConfig{
+			{
+				Name:   "rules",
+				Source: filepath.Join(home, "dotfiles", "rules"),
+				Targets: []ExtraTargetConfig{
+					{Path: filepath.Join(home, ".claude", "rules")},
+				},
+			},
+		},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(cfgPath)
+	got := string(data)
+
+	// Home-rooted paths must be folded
+	for _, want := range []string{
+		"~/dotfiles/skills",
+		"~/my-extras",
+		"~/.claude/skills",
+		"~/.cursor/skills",
+		"~/dotfiles/rules",
+		"~/.claude/rules",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in saved yaml; got:\n%s", want, got)
+		}
+	}
+
+	// Non-home absolute path must remain absolute
+	if !strings.Contains(got, "/opt/weird/skills") {
+		t.Errorf("non-home absolute path should remain absolute; got:\n%s", got)
+	}
+
+	// $HOME should not appear anywhere
+	if strings.Contains(got, home+"/") || strings.HasSuffix(strings.TrimSpace(got), home) {
+		t.Errorf("$HOME prefix should not appear in saved yaml; home=%q got:\n%s", home, got)
+	}
+
+	// In-memory cfg must not be mutated
+	if strings.HasPrefix(cfg.Source, "~") {
+		t.Errorf("in-memory cfg.Source was mutated to %q", cfg.Source)
+	}
+	if cfg.Targets["claude"].Skills.Path[0] == '~' {
+		t.Errorf("in-memory Targets[claude].Skills.Path was mutated")
+	}
+}
+
+func TestSave_PreserveTildeOnSave_Roundtrip(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	t.Setenv("SKILLSHARE_CONFIG", cfgPath)
+
+	home, _ := os.UserHomeDir()
+	cfg := &Config{
+		Source:              filepath.Join(home, "skills"),
+		PreserveTildeOnSave: true,
+		Targets: map[string]TargetConfig{
+			"claude": {Skills: &ResourceTargetConfig{Path: filepath.Join(home, ".claude", "skills")}},
+		},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+	first, _ := os.ReadFile(cfgPath)
+
+	// Load and Save again; on-disk yaml should be idempotent
+	loaded, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !loaded.PreserveTildeOnSave {
+		t.Fatal("PreserveTildeOnSave flag should survive roundtrip")
+	}
+	if err := loaded.Save(); err != nil {
+		t.Fatal(err)
+	}
+	second, _ := os.ReadFile(cfgPath)
+	if string(first) != string(second) {
+		t.Errorf("Save→Load→Save is not idempotent\n--- first ---\n%s\n--- second ---\n%s", first, second)
+	}
+}

--- a/internal/utils/path.go
+++ b/internal/utils/path.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -33,4 +34,46 @@ func PathHasPrefix(path, prefix string) bool {
 		return strings.HasPrefix(strings.ToLower(path), strings.ToLower(prefix))
 	}
 	return strings.HasPrefix(path, prefix)
+}
+
+// FoldHomePath folds an absolute path under the user's home directory back to
+// the ~ form for stable, machine-agnostic YAML serialization.
+//
+// Returns the original path unchanged when:
+//   - input is empty
+//   - user home cannot be determined
+//   - path is not under the home prefix (strict match on home + separator)
+//   - path already starts with ~
+//
+// On Windows ~ is increasingly accepted but not universally honored by shells;
+// we still fold to keep behavior parallel across OSes (downstream consumers
+// already expand via ExpandPath/normalizeTargetPath).
+//
+// fork patch: preserve ~ in saved config paths (iFwu/skillshare).
+func FoldHomePath(path string) string {
+	if path == "" || HasTildePrefix(path) {
+		return path
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return path
+	}
+	return FoldHomePathWith(path, home)
+}
+
+// FoldHomePathWith is the home-explicit form of FoldHomePath. Callers that
+// fold many paths in a tight loop should resolve the home directory once
+// (it can involve a syscall on Windows) and pass it here directly.
+func FoldHomePathWith(path, home string) string {
+	if path == "" || HasTildePrefix(path) || home == "" {
+		return path
+	}
+	if PathsEqual(path, home) {
+		return "~"
+	}
+	sep := string(filepath.Separator)
+	if PathHasPrefix(path, home+sep) {
+		return "~" + path[len(home):]
+	}
+	return path
 }

--- a/internal/utils/path_test.go
+++ b/internal/utils/path_test.go
@@ -1,0 +1,56 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestFoldHomePath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skip("UserHomeDir unavailable")
+	}
+	sep := string(filepath.Separator)
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"already-tilde", "~/foo", "~/foo"},
+		{"exact-home", home, "~"},
+		{"home-child", home + sep + "foo", "~" + sep + "foo"},
+		{"home-deep", home + sep + ".config" + sep + "skillshare", "~" + sep + ".config" + sep + "skillshare"},
+		{"sibling-not-home", home + "_other" + sep + "foo", home + "_other" + sep + "foo"},
+		{"unrelated-abs", "/tmp/foo", "/tmp/foo"},
+		{"relative", "foo/bar", "foo/bar"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FoldHomePath(tt.in)
+			if got != tt.want {
+				t.Errorf("FoldHomePath(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFoldHomePath_WindowsCaseInsensitive(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only case-fold behavior")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("UserHomeDir unavailable")
+	}
+	// Pretend the path comes back with different casing (common on Windows).
+	mixed := strings.ToLower(home) + string(filepath.Separator) + "Foo"
+	got := FoldHomePath(mixed)
+	if !strings.HasPrefix(got, "~") {
+		t.Errorf("FoldHomePath(%q) = %q, expected fold under mixed case", mixed, got)
+	}
+}

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -83,6 +83,11 @@
       "uniqueItems": true,
       "examples": [["azuredevops.mycompany.com"]]
     },
+    "preserve_tilde_on_save": {
+      "type": "boolean",
+      "description": "When true, fold $HOME prefixes back to ~ when serializing this config to YAML. Keeps the on-disk config portable across machines (e.g. when shared via dotfiles). The in-memory config is unaffected; Load() still expands ~ as usual.",
+      "default": false
+    },
     "extras": {
       "type": "array",
       "description": "Non-skill resources (rules, commands, etc.) to sync to specific target paths.",


### PR DESCRIPTION
## Problem

When a user shares their `skillshare` config via dotfiles (or any other cross-machine sync), every `cfg.Save()` call rewrites `~/...` paths into absolute `/home/<user>/...` form. The user-name (and OS-specific home prefix) gets burned into the config, breaking portability and creating noisy diffs on every operation that touches a target.

Repro:
```bash
$ cat ~/.config/skillshare/config.yaml
source: ~/dotfiles/skills
targets:
  claude:
    skills: { path: ~/.claude/skills }

$ skillshare target remove some-other-target
$ cat ~/.config/skillshare/config.yaml
source: /home/alice/dotfiles/skills           # ← expanded
targets:
  claude:
    skills: { path: /home/alice/.claude/skills }  # ← expanded
```

`Load()` expands `~` (correctly — `os.Stat` etc. don't understand `~`), but `Save()` writes the expanded value verbatim, losing the original form.

## Proposal

Add an **opt-in** config flag, default `false` (no behavior change for existing users):

```yaml
preserve_tilde_on_save: true
```

When enabled, `Save()` folds `$HOME` prefixes back to `~` before serialization. The in-memory `Config` is left untouched; we marshal a shallow copy with rewritten path fields. Downstream consumers (sync, validators, etc.) are unaffected.

Folded fields mirror the existing `expandPath()` calls in `Load()`:
- `cfg.Source`, `cfg.ExtrasSource`
- `cfg.Targets[*].Path`, `Skills.Path`, `Agents.Path`
- `cfg.Extras[*].Source`, `Extras[*].Targets[*].Path`

`FoldHomePath()` only folds when:
- The path is strictly under `$HOME` (`home + separator` prefix, or exact `home`)
- The path doesn't already start with `~`
- `os.UserHomeDir()` succeeds

Non-home absolute paths (`/opt/foo`, `/tmp/bar`) and relative paths are passed through unchanged. Windows paths fold via `PathHasPrefix` (case-insensitive on Windows).

## Tests

- `internal/utils/path_test.go`: 7 cases (exact home, child, sibling-non-home, unrelated-abs, relative, empty, already-tilde) + Windows case-fold test.
- `internal/config/config_tilde_fold_test.go`:
  - Default (flag absent) keeps absolute paths.
  - Flag enabled folds all six path fields.
  - Non-home absolute paths are not folded.
  - In-memory `Config` is not mutated.
  - `Save→Load→Save` is byte-for-byte idempotent.

All `internal/...` tests pass on the branch.

## Backward compatibility

Zero. Default `false`. Existing configs and CI behave identically.

## Notes

- I've been running this patch on my own setup for daily dotfiles sync — it makes the config diff stable across my Linux VM, macOS, and Windows machines.
- Happy to rebase / adjust naming / split commits as you prefer.
