### PR TITLE
retain custom name and non-default branch for tracked skills

### DIFF
--- a/internal/install/install_tracked.go
+++ b/internal/install/install_tracked.go
@@ -12,13 +12,13 @@ func installTrackedRepoImpl(source *Source, sourceDir string, opts InstallOption
 		return nil, fmt.Errorf("--track requires a git repository source")
 	}
 
-	// Determine repo name: opts.Name > TrackName (owner-repo) > source.Name
+	// Determine repo name: opts.Name > source.Name (from config) > TrackName (derived from URL)
 	repoName := opts.Name
 	if repoName == "" {
-		repoName = source.TrackName()
+		repoName = source.Name
 	}
 	if repoName == "" {
-		repoName = source.Name
+		repoName = source.TrackName()
 	}
 
 	// Prefix with _ to indicate tracked repo (avoid double prefix if user already added _)
@@ -79,7 +79,12 @@ func installTrackedRepoImpl(source *Source, sourceDir string, opts InstallOption
 
 	// Clone tracked repos with a download-optimized strategy first, then
 	// fallback to the legacy full clone for compatibility.
-	if err := cloneTrackedRepo(source.CloneURL, source.Subdir, destPath, opts.Branch, opts.OnProgress); err != nil {
+	// Prefer CLI --branch over source.Branch (from config); both beat empty.
+	cloneBranch := opts.Branch
+	if cloneBranch == "" {
+		cloneBranch = source.Branch
+	}
+	if err := cloneTrackedRepo(source.CloneURL, source.Subdir, destPath, cloneBranch, opts.OnProgress); err != nil {
 		return nil, fmt.Errorf("failed to clone repository: %w", err)
 	}
 

--- a/internal/install/install_tracked_test.go
+++ b/internal/install/install_tracked_test.go
@@ -1,0 +1,117 @@
+package install
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// makeRemote creates a bare git remote with a SKILL.md on the default branch,
+// plus an optional extra branch if extraBranch != "".
+func makeRemote(t *testing.T, extraBranch string) (remoteURL string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	tmp := t.TempDir()
+	work := filepath.Join(tmp, "work")
+	remote := filepath.Join(tmp, "remote.git")
+
+	mustRunGit(t, "", "init", "-b", "main", work)
+	mustRunGit(t, work, "config", "user.email", "test@test.com")
+	mustRunGit(t, work, "config", "user.name", "Test")
+
+	skillFile := filepath.Join(work, "SKILL.md")
+	if err := os.WriteFile(skillFile, []byte("# test skill"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mustRunGit(t, work, "add", ".")
+	mustRunGit(t, work, "commit", "-m", "init")
+
+	if extraBranch != "" {
+		mustRunGit(t, work, "checkout", "-b", extraBranch)
+		if err := os.WriteFile(skillFile, []byte("# test skill on "+extraBranch), 0644); err != nil {
+			t.Fatal(err)
+		}
+		mustRunGit(t, work, "add", ".")
+		mustRunGit(t, work, "commit", "-m", "branch commit")
+		mustRunGit(t, work, "checkout", "main")
+	}
+
+	mustRunGit(t, "", "clone", "--bare", work, remote)
+	return "file://" + remote
+}
+
+// TestInstallTrackedRepo_NameFromSource verifies that when opts.Name is empty,
+// the directory name is taken from source.Name rather than being derived from
+// the remote URL via TrackName().
+func TestInstallTrackedRepo_NameFromSource(t *testing.T) {
+	remoteURL := makeRemote(t, "")
+	sourceDir := t.TempDir()
+
+	source := &Source{
+		Type:     SourceTypeGitHTTPS,
+		Raw:      remoteURL,
+		CloneURL: remoteURL,
+		Name:     "my-custom-name", // explicit name; should win over TrackName()
+	}
+
+	result, err := InstallTrackedRepo(source, sourceDir, InstallOptions{})
+	if err != nil {
+		t.Fatalf("InstallTrackedRepo() error = %v", err)
+	}
+	if result.Action != "cloned" {
+		t.Fatalf("Action = %q, want %q", result.Action, "cloned")
+	}
+
+	want := filepath.Join(sourceDir, "_my-custom-name")
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("expected repo at %q but stat failed: %v", want, err)
+	}
+	// Confirm the URL-derived name was NOT used.
+	unwanted := filepath.Join(sourceDir, "_"+source.TrackName())
+	if _, err := os.Stat(unwanted); err == nil {
+		t.Fatalf("repo should NOT exist at URL-derived path %q", unwanted)
+	}
+}
+
+// TestInstallTrackedRepo_BranchFromSource verifies that when opts.Branch is
+// empty, the repo is cloned onto source.Branch rather than the remote default.
+func TestInstallTrackedRepo_BranchFromSource(t *testing.T) {
+	const featureBranch = "feature/my-work"
+	remoteURL := makeRemote(t, featureBranch)
+	sourceDir := t.TempDir()
+
+	source := &Source{
+		Type:     SourceTypeGitHTTPS,
+		Raw:      remoteURL,
+		CloneURL: remoteURL,
+		Name:     "mybranch-skill",
+		Branch:   featureBranch, // should be used; opts.Branch is empty
+	}
+
+	result, err := InstallTrackedRepo(source, sourceDir, InstallOptions{})
+	if err != nil {
+		t.Fatalf("InstallTrackedRepo() error = %v", err)
+	}
+	if result.Action != "cloned" {
+		t.Fatalf("Action = %q, want %q", result.Action, "cloned")
+	}
+
+	repoPath := filepath.Join(sourceDir, "_mybranch-skill")
+	if _, err := os.Stat(repoPath); err != nil {
+		t.Fatalf("expected repo at %q: %v", repoPath, err)
+	}
+
+	out, err2 := exec.Command("git", "-C", repoPath, "rev-parse", "--abbrev-ref", "HEAD").Output()
+	if err2 != nil {
+		t.Fatalf("git rev-parse failed: %v", err2)
+	}
+	got := strings.TrimSpace(string(out))
+	if got != featureBranch {
+		t.Errorf("cloned branch = %q, want %q", got, featureBranch)
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing! Please read CONTRIBUTING.md before submitting. -->

## Type

- [X] Bug fix
- [ ] Small improvement (docs, typo, minor refactor)
- [ ] Feature proposal (`proposals/` only — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Linked Issue

Closes #158 

## Checklist

- [X] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [X] Tests included and passing (`make check`) — for code changes
- [X] No unrelated changes in the diff
- [X] Scope is focused — one concern per PR
