### PR TITLE
Treat Swift files as audit-scannable

### DIFF
--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -981,7 +981,7 @@ func isScannable(name string) bool {
 	switch ext {
 	case ".md", ".txt", ".yaml", ".yml", ".json", ".toml",
 		".sh", ".bash", ".zsh", ".fish",
-		".py", ".js", ".ts", ".rb", ".go", ".rs":
+		".py", ".js", ".ts", ".rb", ".go", ".rs", ".swift":
 		return true
 	}
 	// Also scan files without extension (e.g. Makefile, Dockerfile)

--- a/internal/audit/audit_scan_skill_test.go
+++ b/internal/audit/audit_scan_skill_test.go
@@ -133,6 +133,7 @@ func TestIsScannable(t *testing.T) {
 		{"shell", "setup.sh", true},
 		{"python", "script.py", true},
 		{"go", "main.go", true},
+		{"swift", "ViewModel.swift", true},
 		{"no extension", "Makefile", true},
 		{"png", "image.png", false},
 		{"jpg", "photo.jpg", false},


### PR DESCRIPTION
## Summary
- include `.swift` files in the audit scanner
- add Swift coverage to `TestIsScannable`

## Why
Swift-heavy skills can otherwise appear to have low analyzability even when their source files are text and auditable.

## Test
- `go test ./internal/audit`

Co-authored-by: Codex <noreply@openai.com>