### PR TITLE
Reduce audit false positives

### DIFF
--- a/internal/audit/analyzer_metadata.go
+++ b/internal/audit/analyzer_metadata.go
@@ -39,8 +39,11 @@ const (
 	ruleAuthorityLanguage = "authority-language"
 )
 
-// reOrgClaim matches patterns like "from Acme Corp", "by Acme", "@acme".
-var reOrgClaim = regexp.MustCompile(`(?i)(?:from|by|made by|created by|published by|maintained by)\s+([A-Z][\w-]+(?:\s+(?:Corp|Inc|Ltd|Team|Labs|AI|HQ|Co|Group))?)|@([A-Za-z][\w-]+)`)
+// reOrgClaim matches explicit organization claims like "from Acme Corp",
+// "published by Widget Labs", or "@acme". Keep the captured organization
+// case-sensitive so ordinary trigger text such as "from any .docx" or
+// "from CSV data" is not treated as a publisher claim.
+var reOrgClaim = regexp.MustCompile(`(?i:(?:from|by|made by|created by|published by|maintained by))\s+([A-Z][a-z][\w-]*(?:\s+(?:[A-Z][\w-]*|Corp|Inc|Ltd|Team|Labs|AI|HQ|Co|Group))*)|@([A-Za-z][\w-]+)`)
 
 // authorityWords are terms that imply official endorsement.
 var authorityWords = []string{

--- a/internal/audit/analyzer_metadata_test.go
+++ b/internal/audit/analyzer_metadata_test.go
@@ -120,6 +120,27 @@ func TestCheckPublisherMismatch(t *testing.T) {
 			wantNil: true,
 		},
 		{
+			name:    "trigger text: from any docx is not a publisher claim",
+			skillN:  "officecli-docx",
+			desc:    "Use this skill any time a .docx file is involved -- as input from any document.",
+			repoURL: "https://github.com/iOfficeAI/OfficeCLI.git",
+			wantNil: true,
+		},
+		{
+			name:    "trigger text: from CSV data is not a publisher claim",
+			skillN:  "officecli-data-dashboard",
+			desc:    "Create dashboards from CSV/tabular data in Excel format.",
+			repoURL: "https://github.com/iOfficeAI/OfficeCLI.git",
+			wantNil: true,
+		},
+		{
+			name:    "trigger text: from human-friendly names is not a publisher claim",
+			skillN:  "asc-id-resolver",
+			desc:    "Resolve App Store Connect IDs from human-friendly names using asc.",
+			repoURL: "https://github.com/rudrankriyam/asc-skills.git",
+			wantNil: true,
+		},
+		{
 			name:    "empty repo URL",
 			skillN:  "tool",
 			desc:    "from Acme Corp",

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -1282,9 +1282,6 @@ func extractInlineLinksFromLine(line string, lineNum int, codeSpans []span) []ma
 		}
 
 		j := labelEnd + 1
-		for j < len(line) && (line[j] == ' ' || line[j] == '\t') {
-			j++
-		}
 		if j >= len(line) || line[j] != '(' {
 			i = labelEnd
 			continue
@@ -1624,13 +1621,35 @@ func isLikelyTutorialPath(path string) bool {
 func isExternalOrAnchor(target string) bool {
 	lower := strings.ToLower(target)
 	for _, prefix := range []string{
-		"http://", "https://", "mailto:", "tel:", "data:", "ftp://", "//",
+		"http://", "https://", "mailto:", "tel:", "data:", "ftp://", "file:", "//",
 	} {
 		if strings.HasPrefix(lower, prefix) {
 			return true
 		}
 	}
+	if idx := strings.IndexByte(target, ':'); idx > 0 {
+		scheme := target[:idx]
+		if isURLScheme(scheme) {
+			return true
+		}
+	}
 	return strings.HasPrefix(target, "#")
+}
+
+func isURLScheme(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		if r >= 'a' && r <= 'z' {
+			continue
+		}
+		if i > 0 && ((r >= '0' && r <= '9') || r == '+' || r == '-' || r == '.') {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 // checkContentIntegrity compares files on disk against pinned hashes in the

--- a/internal/audit/audit_scan_skill_test.go
+++ b/internal/audit/audit_scan_skill_test.go
@@ -232,6 +232,42 @@ func TestScanSkill_ExternalLinkSkipped(t *testing.T) {
 	}
 }
 
+func TestScanSkill_DanglingLink_CustomSchemeSkipped(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "my-skill")
+	os.MkdirAll(skillDir, 0755)
+	os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
+		[]byte("# Skill\n\n[open viewer](vscode://ms-windows-ai-studio.windows-ai-studio/open_data_viewer?file=<file_path>)\n"), 0644)
+
+	result, err := ScanSkill(skillDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range result.Findings {
+		if f.Pattern == "dangling-link" {
+			t.Errorf("unexpected dangling-link finding for custom URI scheme: %+v", f)
+		}
+	}
+}
+
+func TestScanSkill_DanglingLink_BracketPlaceholderWithFollowingParens_NoFinding(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "my-skill")
+	os.MkdirAll(skillDir, 0755)
+	os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
+		[]byte("# Skill\n\n- **Duplicate Rows**: [Count] ([Percentage]%)\n"), 0644)
+
+	result, err := ScanSkill(skillDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range result.Findings {
+		if f.Pattern == "dangling-link" {
+			t.Errorf("unexpected dangling-link finding for bracket placeholder text: %+v", f)
+		}
+	}
+}
+
 func TestScanSkill_AnchorLinkSkipped(t *testing.T) {
 	dir := t.TempDir()
 	skillDir := filepath.Join(dir, "my-skill")
@@ -677,6 +713,24 @@ func TestScanSkill_DocumentationLink_OnlyExternal(t *testing.T) {
 	}
 	if !foundExternal {
 		t.Error("documentation link should trigger external-link")
+	}
+}
+
+func TestScanSkill_TrustedDocumentationLinkSkipped(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "trusted-doc-skill")
+	os.MkdirAll(skillDir, 0755)
+	os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
+		[]byte("# Skill\n\n[Microsoft docs](https://learn.microsoft.com/en-us/azure/ai-foundry/)\n"), 0644)
+
+	result, err := ScanSkill(skillDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range result.Findings {
+		if f.Pattern == "external-link" {
+			t.Errorf("unexpected external-link finding for trusted documentation link: %+v", f)
+		}
 	}
 }
 

--- a/internal/audit/rules.yaml
+++ b/internal/audit/rules.yaml
@@ -224,7 +224,7 @@ rules:
     pattern: external-link
     message: "External URL in markdown link"
     regex: '\]\(https?://[^)]+\)'
-    exclude: '(?i)\]\(https?://(localhost|127\.0\.0\.1|0\.0\.0\.0)[:/)]'
+    exclude: '(?i)\]\(https?://(localhost|127\.0\.0\.1|0\.0\.0\.0|learn\.microsoft\.com|developers\.figma\.com|developer\.mozilla\.org|lawsofux\.com|help\.figma\.com|developer\.apple\.com|help\.obsidian\.md|azure\.microsoft\.com|web\.dev|www\.microsoft\.com|opentelemetry\.io|nextjs\.org|motion\.dev|www\.radix-ui\.com|ui\.shadcn\.com|tailwindcss\.com|caniuse\.com)([:/)]|\?)'
 
   # ── HIGH: remote code execution (pipe to interpreter) ──
   - id: fetch-with-pipe-0


### PR DESCRIPTION
## Summary
- tighten publisher mismatch extraction so trigger text like “from any .docx”, “from CSV data”, and “from human-friendly names” is not treated as an origin claim
- skip custom URI schemes and bracket placeholders in dangling-link checks
- allow common documentation domains for markdown external-link noise while preserving unknown external-link warnings

## Verification
- go test ./internal/audit
- built a local test binary and re-ran the global audit against Kosta’s skill library: warning skills 186 -> 178, external-link findings 1189 -> 502, failed 0, critical 0, scanErrors 0

Co-authored-by: Codex <noreply@openai.com>