### PR TITLE
Add doctor suggestions for overlapping skill roots

### DIFF
--- a/cmd/skillshare/doctor.go
+++ b/cmd/skillshare/doctor.go
@@ -39,8 +39,12 @@ func (r *doctorResult) addWarning() {
 }
 
 func (r *doctorResult) addCheck(name, status, message string, details []string) {
+	r.addCheckWithSuggestions(name, status, message, details, nil)
+}
+
+func (r *doctorResult) addCheckWithSuggestions(name, status, message string, details []string, suggestions []string) {
 	r.checks = append(r.checks, doctorCheck{
-		Name: name, Status: status, Message: message, Details: details,
+		Name: name, Status: status, Message: message, Details: details, Suggestions: suggestions,
 	})
 }
 

--- a/cmd/skillshare/doctor_json.go
+++ b/cmd/skillshare/doctor_json.go
@@ -16,10 +16,11 @@ const (
 
 // doctorCheck represents a single health check result for JSON output.
 type doctorCheck struct {
-	Name    string   `json:"name"`
-	Status  string   `json:"status"` // checkPass, checkWarning, checkError
-	Message string   `json:"message"`
-	Details []string `json:"details,omitempty"`
+	Name        string   `json:"name"`
+	Status      string   `json:"status"` // checkPass, checkWarning, checkError
+	Message     string   `json:"message"`
+	Details     []string `json:"details,omitempty"`
+	Suggestions []string `json:"suggestions,omitempty"`
 }
 
 type doctorOutput struct {

--- a/cmd/skillshare/doctor_shared_paths.go
+++ b/cmd/skillshare/doctor_shared_paths.go
@@ -51,14 +51,18 @@ func checkSharedTargetPaths(cfg *config.Config, result *doctorResult) {
 	})
 
 	details := make([]string, 0, len(collisions))
+	suggestions := make([]string, 0, len(collisions))
 	for _, c := range collisions {
 		ui.Warning("Shared path %s ← %s", c.path, strings.Join(c.targets, ", "))
 		details = append(details, fmt.Sprintf("%s ← %s", c.path, strings.Join(c.targets, ", ")))
+		suggestion := fmt.Sprintf("Choose one authoritative target for %s; disable or reconfigure the others: %s", c.path, strings.Join(c.targets, ", "))
+		fmt.Println(ui.DimText("    suggestion: " + suggestion))
+		suggestions = append(suggestions, suggestion)
 		result.addWarning()
 	}
 
 	msg := fmt.Sprintf("%d shared target path(s) — enabled targets writing to the same directory may produce duplicate skills in runtime pickers", len(collisions))
-	result.addCheck("shared_target_paths", checkWarning, msg, details)
+	result.addCheckWithSuggestions("shared_target_paths", checkWarning, msg, details, suggestions)
 }
 
 // checkCrossTargetDiscovery warns when an enabled target's runtime is
@@ -138,6 +142,7 @@ func checkCrossTargetDiscovery(cfg *config.Config, result *doctorResult, isProje
 	sort.Strings(scannerNames)
 
 	var details []string
+	var suggestions []string
 	for _, name := range scannerNames {
 		so := overlapsByScanner[name]
 		sort.Slice(so.paths, func(i, j int) bool { return so.paths[i].sharedPath < so.paths[j].sharedPath })
@@ -156,6 +161,9 @@ func checkCrossTargetDiscovery(cfg *config.Config, result *doctorResult, isProje
 		sort.Strings(writers)
 
 		ui.Warning("%s will see content from: %s", so.scanner, strings.Join(writers, ", "))
+		suggestion := fmt.Sprintf("Choose one authoritative route for %s-visible skills; disable or reconfigure overlapping writer target(s): %s", so.scanner, strings.Join(writers, ", "))
+		fmt.Println(ui.DimText("    suggestion: " + suggestion))
+		suggestions = append(suggestions, suggestion)
 		for _, p := range so.paths {
 			fmt.Println(ui.DimText(fmt.Sprintf("    %s ← %s", p.sharedPath, strings.Join(p.writers, ", "))))
 			details = append(details, fmt.Sprintf("%s (%s) also scans %s ← %s",
@@ -165,5 +173,5 @@ func checkCrossTargetDiscovery(cfg *config.Config, result *doctorResult, isProje
 	}
 
 	msg := fmt.Sprintf("%d target(s) overlap with other targets' content via cross-runtime discovery", len(scannerNames))
-	result.addCheck("cross_target_discovery", checkWarning, msg, details)
+	result.addCheckWithSuggestions("cross_target_discovery", checkWarning, msg, details, suggestions)
 }

--- a/cmd/skillshare/doctor_shared_paths_test.go
+++ b/cmd/skillshare/doctor_shared_paths_test.go
@@ -49,6 +49,15 @@ func TestCheckSharedTargetPaths_Collision(t *testing.T) {
 			t.Errorf("detail %q missing %q", detail, want)
 		}
 	}
+	if len(r.checks[0].Suggestions) != 1 {
+		t.Fatalf("expected one suggestion, got %v", r.checks[0].Suggestions)
+	}
+	suggestion := r.checks[0].Suggestions[0]
+	for _, want := range []string{"Choose one authoritative target", "universal", "warp", "witsy", "/tmp/.agents/skills"} {
+		if !strings.Contains(suggestion, want) {
+			t.Errorf("suggestion %q missing %q", suggestion, want)
+		}
+	}
 	if strings.Contains(detail, "claude") {
 		t.Errorf("claude should not appear in collision detail: %q", detail)
 	}
@@ -88,6 +97,15 @@ func TestCheckCrossTargetDiscovery_CodexSeesUniversal(t *testing.T) {
 	for _, want := range []string{"codex", "universal", ".agents/skills"} {
 		if !strings.Contains(detail, want) {
 			t.Errorf("detail %q missing %q", detail, want)
+		}
+	}
+	if len(r.checks[0].Suggestions) != 1 {
+		t.Fatalf("expected one suggestion, got %v", r.checks[0].Suggestions)
+	}
+	suggestion := r.checks[0].Suggestions[0]
+	for _, want := range []string{"Choose one authoritative route", "codex", "universal"} {
+		if !strings.Contains(suggestion, want) {
+			t.Errorf("suggestion %q missing %q", suggestion, want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Added optional structured `suggestions` to doctor check JSON output.
- Surfaced actionable remediation guidance for shared target paths and cross-target discovery overlaps.
- Covered both warning paths with focused tests.

## Context
Related to #135. The existing doctor checks already detect duplicate roots and cross-target discovery overlaps, but the warning output did not tell users what to do next. This keeps the change narrow: it does not add adopt/claim behavior, change sync semantics, or introduce new config models.

## Validation
- `go test ./cmd/skillshare -run 'TestCheckSharedTargetPaths|TestCheckCrossTargetDiscovery|TestFinalizeDoctorJSON|TestFetchDoctorUpdateResult'`
- `make test-unit`

The visible Vercel status points at a Vercel authorization URL; no Go test failure was observed locally.
