### PR TITLE
Feat/extras cli add remove target

### DIFF
--- a/cmd/skillshare/extras.go
+++ b/cmd/skillshare/extras.go
@@ -14,6 +14,10 @@ func cmdExtras(args []string) error {
 	switch sub {
 	case "init":
 		return cmdExtrasInit(rest)
+	case "add-target":
+		return cmdExtrasAddTarget(rest)
+	case "remove-target":
+		return cmdExtrasRemoveTarget(rest)
 	case "list", "ls":
 		return cmdExtrasList(rest)
 	case "remove", "rm":
@@ -42,12 +46,14 @@ func printExtrasHelp() {
 Manage non-skill resources (rules, commands, prompts, etc.).
 
 Commands:
-  init <name>        Create a new extra resource type
-  list               List all configured extras and sync status (interactive TUI)
-  remove <name>      Remove an extra resource type
-  collect <name>     Collect local files from a target into extras source
-  source [path]      Show or set the global extras_source directory
-  mode <name>        Change sync mode or flatten setting of an extra's target
+  init <name>           Create a new extra resource type
+  add-target <name>     Add a target to an existing extra
+  remove-target <name>  Remove a target from an existing extra
+  list                  List all configured extras and sync status (interactive TUI)
+  remove <name>         Remove an extra resource type
+  collect <name>        Collect local files from a target into extras source
+  source [path]         Show or set the global extras_source directory
+  mode <name>           Change sync mode or flatten setting of an extra's target
 
 Shortcuts:
   skillshare extras <name> --mode <mode>       Change sync mode

--- a/cmd/skillshare/extras_add_target.go
+++ b/cmd/skillshare/extras_add_target.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"skillshare/internal/config"
+	"skillshare/internal/oplog"
+	"skillshare/internal/ui"
+)
+
+func cmdExtrasAddTarget(args []string) error {
+	start := time.Now()
+
+	mode, rest, err := parseModeArgs(args)
+	if err != nil {
+		return err
+	}
+
+	cwd, _ := os.Getwd()
+	if mode == modeAuto {
+		if projectConfigExists(cwd) {
+			mode = modeProject
+		} else {
+			mode = modeGlobal
+		}
+	}
+
+	applyModeLabel(mode)
+
+	var name, targetPath, syncMode string
+	var flatten bool
+	for i := 0; i < len(rest); i++ {
+		switch rest[i] {
+		case "--target":
+			if i+1 >= len(rest) {
+				return fmt.Errorf("--target requires a path argument")
+			}
+			i++
+			targetPath = rest[i]
+		case "--mode":
+			if i+1 >= len(rest) {
+				return fmt.Errorf("--mode requires an argument (merge/copy/symlink)")
+			}
+			i++
+			syncMode = rest[i]
+		case "--flatten":
+			flatten = true
+		case "--help", "-h":
+			printExtrasAddTargetHelp()
+			return nil
+		default:
+			if name == "" {
+				name = rest[i]
+			} else {
+				return fmt.Errorf("unexpected argument: %s", rest[i])
+			}
+		}
+	}
+
+	if name == "" {
+		return fmt.Errorf("extras name is required: skillshare extras add-target <name> --target <path>")
+	}
+	if targetPath == "" {
+		return fmt.Errorf("--target is required")
+	}
+
+	if err := config.ValidateExtraMode(syncMode); err != nil {
+		return err
+	}
+	if flatten {
+		if err := config.ValidateExtraFlatten(true, syncMode); err != nil {
+			return err
+		}
+	}
+
+	// Load config based on mode
+	var extras []config.ExtraConfig
+	var configPath string
+	var saveFn func() error
+
+	if mode == modeProject {
+		projCfg, loadErr := config.LoadProject(cwd)
+		if loadErr != nil {
+			return loadErr
+		}
+		extras = projCfg.Extras
+		configPath = config.ProjectConfigPath(cwd)
+		saveFn = func() error { return projCfg.Save(cwd) }
+	} else {
+		cfg, loadErr := config.Load()
+		if loadErr != nil {
+			return loadErr
+		}
+		extras = cfg.Extras
+		configPath = config.ConfigPath()
+		saveFn = cfg.Save
+	}
+
+	// Locate the extra and verify target uniqueness.
+	idx := -1
+	for i, e := range extras {
+		if e.Name == name {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return fmt.Errorf("extra %q not found", name)
+	}
+	for _, t := range extras[idx].Targets {
+		if t.Path == targetPath {
+			return fmt.Errorf("target %q already exists for extra %q", targetPath, name)
+		}
+	}
+
+	newTarget := config.ExtraTargetConfig{Path: targetPath, Flatten: flatten}
+	if syncMode != "" {
+		newTarget.Mode = syncMode
+	}
+	extras[idx].Targets = append(extras[idx].Targets, newTarget)
+
+	if err := saveFn(); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	ui.Success("Added target to %s: %s (mode=%s)", name, shortenPath(targetPath), syncMode)
+
+	e := oplog.NewEntry("extras-add-target", "ok", time.Since(start))
+	e.Args = map[string]any{"name": name, "target": targetPath, "mode": syncMode, "flatten": flatten}
+	oplog.WriteWithLimit(configPath, oplog.OpsFile, e, logMaxEntries()) //nolint:errcheck
+
+	return nil
+}
+
+func printExtrasAddTargetHelp() {
+	fmt.Println(`Usage: skillshare extras add-target <name> --target <path> [options]
+
+Add a new target directory to an existing extra.
+
+Arguments:
+  name                Name of the existing extra (e.g., rules, commands)
+
+Options:
+  --target <path>     Target directory to add (required)
+  --mode <mode>       Sync mode: merge (default), copy, or symlink
+  --flatten           Flatten files from subdirectories into target root
+  --project, -p       Use project mode (.skillshare/)
+  --global, -g        Use global mode (~/.config/skillshare/)
+  --help, -h          Show this help
+
+Examples:
+  skillshare extras add-target rules --target ~/.cursor/rules
+  skillshare extras add-target commands --target ~/.claude/commands --mode copy
+  skillshare extras add-target agents --target ~/.claude/agents --flatten -p`)
+}

--- a/cmd/skillshare/extras_add_target.go
+++ b/cmd/skillshare/extras_add_target.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"skillshare/internal/config"
@@ -51,6 +52,9 @@ func cmdExtrasAddTarget(args []string) error {
 			printExtrasAddTargetHelp()
 			return nil
 		default:
+			if len(rest[i]) > 0 && rest[i][0] == '-' {
+				return fmt.Errorf("unexpected flag: %s", rest[i])
+			}
 			if name == "" {
 				name = rest[i]
 			} else {
@@ -65,6 +69,7 @@ func cmdExtrasAddTarget(args []string) error {
 	if targetPath == "" {
 		return fmt.Errorf("--target is required")
 	}
+	targetPath = filepath.Clean(targetPath)
 
 	if err := config.ValidateExtraMode(syncMode); err != nil {
 		return err

--- a/cmd/skillshare/extras_add_target.go
+++ b/cmd/skillshare/extras_add_target.go
@@ -69,7 +69,7 @@ func cmdExtrasAddTarget(args []string) error {
 	if targetPath == "" {
 		return fmt.Errorf("--target is required")
 	}
-	targetPath = filepath.Clean(targetPath)
+	targetPath = filepath.Clean(config.ExpandPath(targetPath))
 
 	if err := config.ValidateExtraMode(syncMode); err != nil {
 		return err

--- a/cmd/skillshare/extras_remove_target.go
+++ b/cmd/skillshare/extras_remove_target.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"skillshare/internal/config"
+	"skillshare/internal/oplog"
+	"skillshare/internal/ui"
+)
+
+func cmdExtrasRemoveTarget(args []string) error {
+	start := time.Now()
+
+	mode, rest, err := parseModeArgs(args)
+	if err != nil {
+		return err
+	}
+
+	cwd, _ := os.Getwd()
+	if mode == modeAuto {
+		if projectConfigExists(cwd) {
+			mode = modeProject
+		} else {
+			mode = modeGlobal
+		}
+	}
+
+	applyModeLabel(mode)
+
+	var name, targetPath string
+	for i := 0; i < len(rest); i++ {
+		switch rest[i] {
+		case "--target":
+			if i+1 >= len(rest) {
+				return fmt.Errorf("--target requires a path argument")
+			}
+			i++
+			targetPath = rest[i]
+		case "--help", "-h":
+			printExtrasRemoveTargetHelp()
+			return nil
+		default:
+			if name == "" {
+				name = rest[i]
+			} else {
+				return fmt.Errorf("unexpected argument: %s", rest[i])
+			}
+		}
+	}
+
+	if name == "" {
+		return fmt.Errorf("extras name is required: skillshare extras remove-target <name> --target <path>")
+	}
+	if targetPath == "" {
+		return fmt.Errorf("--target is required")
+	}
+
+	// Load config based on mode
+	var extras []config.ExtraConfig
+	var configPath string
+	var saveFn func() error
+
+	if mode == modeProject {
+		projCfg, loadErr := config.LoadProject(cwd)
+		if loadErr != nil {
+			return loadErr
+		}
+		extras = projCfg.Extras
+		configPath = config.ProjectConfigPath(cwd)
+		saveFn = func() error { return projCfg.Save(cwd) }
+	} else {
+		cfg, loadErr := config.Load()
+		if loadErr != nil {
+			return loadErr
+		}
+		extras = cfg.Extras
+		configPath = config.ConfigPath()
+		saveFn = cfg.Save
+	}
+
+	// Locate the extra.
+	extraIdx := -1
+	for i, e := range extras {
+		if e.Name == name {
+			extraIdx = i
+			break
+		}
+	}
+	if extraIdx == -1 {
+		return fmt.Errorf("extra %q not found", name)
+	}
+
+	// Locate the target.
+	targetIdx := -1
+	for j, t := range extras[extraIdx].Targets {
+		if t.Path == targetPath {
+			targetIdx = j
+			break
+		}
+	}
+	if targetIdx == -1 {
+		return fmt.Errorf("target %q not found in extra %q", targetPath, name)
+	}
+
+	// Splice out the target. NOTE: we deliberately do NOT touch files on disk —
+	// already-synced files in the target directory remain. Same contract as the
+	// HTTP DELETE handler.
+	ts := extras[extraIdx].Targets
+	extras[extraIdx].Targets = append(ts[:targetIdx], ts[targetIdx+1:]...)
+
+	if err := saveFn(); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	ui.Success("Removed target from %s: %s", name, shortenPath(targetPath))
+
+	e := oplog.NewEntry("extras-remove-target", "ok", time.Since(start))
+	e.Args = map[string]any{"name": name, "target": targetPath}
+	oplog.WriteWithLimit(configPath, oplog.OpsFile, e, logMaxEntries()) //nolint:errcheck
+
+	return nil
+}
+
+func printExtrasRemoveTargetHelp() {
+	fmt.Println(`Usage: skillshare extras remove-target <name> --target <path> [options]
+
+Remove a target directory from an existing extra.
+
+Files already synced to the target directory are NOT deleted — only the
+config entry is removed. Run 'skillshare sync extras' afterwards to clean
+up orphaned links.
+
+Arguments:
+  name                Name of the existing extra
+
+Options:
+  --target <path>     Target directory to remove (required)
+  --project, -p       Use project mode (.skillshare/)
+  --global, -g        Use global mode (~/.config/skillshare/)
+  --help, -h          Show this help
+
+Examples:
+  skillshare extras remove-target rules --target ~/.cursor/rules
+  skillshare extras remove-target agents --target .claude/agents -p`)
+}

--- a/cmd/skillshare/extras_remove_target.go
+++ b/cmd/skillshare/extras_remove_target.go
@@ -60,7 +60,7 @@ func cmdExtrasRemoveTarget(args []string) error {
 	if targetPath == "" {
 		return fmt.Errorf("--target is required")
 	}
-	targetPath = filepath.Clean(targetPath)
+	targetPath = filepath.Clean(config.ExpandPath(targetPath))
 
 	// Load config based on mode
 	var extras []config.ExtraConfig

--- a/cmd/skillshare/extras_remove_target.go
+++ b/cmd/skillshare/extras_remove_target.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"skillshare/internal/config"
@@ -42,6 +43,9 @@ func cmdExtrasRemoveTarget(args []string) error {
 			printExtrasRemoveTargetHelp()
 			return nil
 		default:
+			if len(rest[i]) > 0 && rest[i][0] == '-' {
+				return fmt.Errorf("unexpected flag: %s", rest[i])
+			}
 			if name == "" {
 				name = rest[i]
 			} else {
@@ -56,6 +60,7 @@ func cmdExtrasRemoveTarget(args []string) error {
 	if targetPath == "" {
 		return fmt.Errorf("--target is required")
 	}
+	targetPath = filepath.Clean(targetPath)
 
 	// Load config based on mode
 	var extras []config.ExtraConfig
@@ -108,7 +113,9 @@ func cmdExtrasRemoveTarget(args []string) error {
 	// already-synced files in the target directory remain. Same contract as the
 	// HTTP DELETE handler.
 	ts := extras[extraIdx].Targets
-	extras[extraIdx].Targets = append(ts[:targetIdx], ts[targetIdx+1:]...)
+	copy(ts[targetIdx:], ts[targetIdx+1:])
+	ts[len(ts)-1] = config.ExtraTargetConfig{}
+	extras[extraIdx].Targets = ts[:len(ts)-1]
 
 	if err := saveFn(); err != nil {
 		return fmt.Errorf("failed to save config: %w", err)


### PR DESCRIPTION
  Type

  - [x] Feature

  Description

  Adds two new CLI subcommands to manage targets on existing extras without recreating them:

  - skillshare extras add-target <name> --target <path> [--mode <mode>] [--flatten]
  - skillshare extras remove-target <name> --target <path>

  Both commands support --project/--global mode flags and write to the oplog. The remove command intentionally does not delete already-synced files from disk — only
  the config entry is removed (same contract as the HTTP DELETE handler).

  Linked Issue

  Closes #

  Checklist

  - [x] I've read CONTRIBUTING.md
  - [x] Tests included and passing (make check)
  - [x] No unrelated changes in the diff
  - [x] Scope is focused — one concern per PR