### PR TITLE
fix(audit): respect .skillignore for tracked hub repos in audit scan

### DIFF
--- a/cmd/skillshare/audit.go
+++ b/cmd/skillshare/audit.go
@@ -436,8 +436,8 @@ func collectInstalledSkillPaths(sourcePath string) ([]auditSkillRef, error) {
 
 	entries, _ := os.ReadDir(sourcePath)
 	for _, e := range entries {
-		if !e.IsDir() || utils.IsHidden(e.Name()) {
-			continue
+		if !e.IsDir() || utils.IsHidden(e.Name()) || utils.IsTrackedRepoDir(e.Name()) {
+			continue  // tracked hub repos already handled by DiscoverSourceSkillsLite
 		}
 		p := filepath.Join(sourcePath, e.Name())
 		if !seen[p] {

--- a/internal/utils/strings.go
+++ b/internal/utils/strings.go
@@ -53,7 +53,7 @@ func FlatNameToPath(flatName string) string {
 // IsTrackedRepoDir checks if a directory name indicates a tracked repository.
 // Tracked repos start with _ and contain .git directory.
 func IsTrackedRepoDir(name string) bool {
-	return len(name) > 0 && name[0] == '_'
+	return strings.HasPrefix(name, TrackedRepoPrefix)
 }
 
 // HasNestedSeparator checks if a name contains the nested separator (__).

--- a/tests/integration/audit_test.go
+++ b/tests/integration/audit_test.go
@@ -1595,3 +1595,68 @@ func TestAudit_SkillsTerminology(t *testing.T) {
 	result.AssertOutputNotContains(t, "agent(s)")
 	result.AssertOutputNotContains(t, "Scanned:   1 agent")
 }
+
+// TestAudit_TrackedHubRepo_SkillIgnoreRespected is a regression test for the bug
+// where the raw os.ReadDir fallback pass in collectInstalledSkillPaths bypassed
+// .skillignore for _-prefixed tracked hub repos, causing the repo dir itself to
+// appear as an extra skill in the audit scan.
+//
+// Before the fix: Scanned count would be 2 (_myhub + _myhub__real-skill).
+// After the fix:  Scanned count is 1 (only _myhub__real-skill).
+func TestAudit_TrackedHubRepo_SkillIgnoreRespected(t *testing.T) {
+	sb := testutil.NewSandbox(t)
+	defer sb.Cleanup()
+
+	// Simulate a tracked hub repo installed under a _-prefixed directory.
+	repoDir := filepath.Join(sb.SourcePath, "_myhub")
+	os.MkdirAll(filepath.Join(repoDir, ".git"), 0755)
+	os.WriteFile(filepath.Join(repoDir, ".skillignore"), []byte("README.md\nscripts/\n"), 0644)
+
+	// A real skill inside the hub — should be scanned.
+	os.MkdirAll(filepath.Join(repoDir, "real-skill"), 0755)
+	os.WriteFile(filepath.Join(repoDir, "real-skill", "SKILL.md"),
+		[]byte("---\nname: real-skill\n---\n# Real skill\nFollow best practices."), 0644)
+
+	// Files/dirs excluded by .skillignore — must not be treated as skills.
+	os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("# Hub readme"), 0644)
+	os.MkdirAll(filepath.Join(repoDir, "scripts"), 0755)
+	os.WriteFile(filepath.Join(repoDir, "scripts", "setup.sh"), []byte("#!/bin/sh\n"), 0644)
+
+	sb.WriteConfig(`source: ` + sb.SourcePath + "\ntargets: {}\n")
+
+	result := sb.RunCLI("audit", "--no-tui")
+	result.AssertSuccess(t)
+
+	// Only the one real skill should have been scanned.
+	result.AssertAnyOutputContains(t, "Scanned:   1")
+
+	// The hub dir itself must not appear as a scanned skill.
+	result.AssertOutputNotContains(t, "Scanned:   2")
+}
+
+// TestAudit_TrackedHubRepo_PlainSkillsStillIncluded ensures the fallback pass
+// still picks up plain top-level skill dirs that are not inside a tracked repo.
+func TestAudit_TrackedHubRepo_PlainSkillsStillIncluded(t *testing.T) {
+	sb := testutil.NewSandbox(t)
+	defer sb.Cleanup()
+
+	// A plain top-level skill (no _-prefix).
+	sb.CreateSkill("plain-skill", map[string]string{
+		"SKILL.md": "---\nname: plain-skill\n---\n# Safe skill\nFollow best practices.",
+	})
+
+	// A tracked hub repo with one skill.
+	repoDir := filepath.Join(sb.SourcePath, "_myhub")
+	os.MkdirAll(filepath.Join(repoDir, ".git"), 0755)
+	os.MkdirAll(filepath.Join(repoDir, "hub-skill"), 0755)
+	os.WriteFile(filepath.Join(repoDir, "hub-skill", "SKILL.md"),
+		[]byte("---\nname: hub-skill\n---\n# Hub skill\nFollow best practices."), 0644)
+
+	sb.WriteConfig(`source: ` + sb.SourcePath + "\ntargets: {}\n")
+
+	result := sb.RunCLI("audit", "--no-tui")
+	result.AssertSuccess(t)
+
+	// Both the plain skill and the hub skill should be scanned.
+	result.AssertAnyOutputContains(t, "Scanned:   2")
+}


### PR DESCRIPTION
# Type

- [X] Bug fix
- [ ] Small improvement (docs, typo, minor refactor)
- [ ] Feature proposal (`proposals/` only — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Linked Issue

Closes #191 

## Checklist

- [X] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [X] Tests included and passing (`make check`) — for code changes
- [X] No unrelated changes in the diff
- [X] Scope is focused — one concern per PR
