### PR TITLE
feat: add SKILLSHARE_NO_TUI env override

### DIFF
--- a/cmd/skillshare/tui_helpers.go
+++ b/cmd/skillshare/tui_helpers.go
@@ -12,7 +12,8 @@ import (
 )
 
 // shouldLaunchTUI determines whether to launch interactive TUI.
-// Priority: --no-tui flag (force off) > config tui field > default (true).
+// Priority: --no-tui flag (force off) > SKILLSHARE_NO_TUI env var
+// > config tui field > default (true).
 // Pass cfg if already loaded; pass nil to auto-load best-effort.
 func shouldLaunchTUI(noTUI bool, cfg *config.Config) bool {
 	if noTUI {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -429,11 +429,23 @@ func (c *Config) EffectiveAzureHosts() []string {
 
 // IsTUIEnabled reports whether interactive TUI is enabled.
 // nil (absent from config) is treated as true for backward compatibility.
+// The SKILLSHARE_NO_TUI environment variable can override this: when set
+// to "1", "true", or "yes" (case-insensitive, whitespace-trimmed), TUI is
+// disabled without modifying the config file.
 func (c *Config) IsTUIEnabled() bool {
+	if envNoTUI() {
+		return false
+	}
 	if c.TUI == nil {
 		return true
 	}
 	return *c.TUI
+}
+
+// envNoTUI checks the SKILLSHARE_NO_TUI environment variable.
+func envNoTUI() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("SKILLSHARE_NO_TUI")))
+	return v == "1" || v == "true" || v == "yes"
 }
 
 const defaultAuditBlockThreshold = "CRITICAL"

--- a/internal/config/tui_env_test.go
+++ b/internal/config/tui_env_test.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestIsTUIEnabled_Default(t *testing.T) {
+	cfg := &Config{}
+	if !cfg.IsTUIEnabled() {
+		t.Error("expected TUI enabled by default when TUI field is nil")
+	}
+}
+
+func TestIsTUIEnabled_ConfigTrue(t *testing.T) {
+	b := true
+	cfg := &Config{TUI: &b}
+	if !cfg.IsTUIEnabled() {
+		t.Error("expected TUI enabled when config is true")
+	}
+}
+
+func TestIsTUIEnabled_ConfigFalse(t *testing.T) {
+	b := false
+	cfg := &Config{TUI: &b}
+	if cfg.IsTUIEnabled() {
+		t.Error("expected TUI disabled when config is false")
+	}
+}
+
+func TestIsTUIEnabled_EnvOverridesConfigTrue(t *testing.T) {
+	t.Setenv("SKILLSHARE_NO_TUI", "1")
+	b := true
+	cfg := &Config{TUI: &b}
+	if cfg.IsTUIEnabled() {
+		t.Error("expected SKILLSHARE_NO_TUI=1 to disable TUI even when config is true")
+	}
+}
+
+func TestIsTUIEnabled_EnvOverridesConfigNil(t *testing.T) {
+	t.Setenv("SKILLSHARE_NO_TUI", "1")
+	cfg := &Config{}
+	if cfg.IsTUIEnabled() {
+		t.Error("expected SKILLSHARE_NO_TUI=1 to disable TUI with nil config")
+	}
+}
+
+func TestIsTUIEnabled_EnvValueTrue(t *testing.T) {
+	t.Setenv("SKILLSHARE_NO_TUI", "true")
+	cfg := &Config{}
+	if cfg.IsTUIEnabled() {
+		t.Error("expected SKILLSHARE_NO_TUI=true to disable TUI")
+	}
+}
+
+func TestIsTUIEnabled_EnvValueYes(t *testing.T) {
+	t.Setenv("SKILLSHARE_NO_TUI", "yes")
+	cfg := &Config{}
+	if cfg.IsTUIEnabled() {
+		t.Error("expected SKILLSHARE_NO_TUI=yes to disable TUI")
+	}
+}
+
+func TestIsTUIEnabled_EnvCaseInsensitive(t *testing.T) {
+	t.Setenv("SKILLSHARE_NO_TUI", "TRUE")
+	cfg := &Config{}
+	if cfg.IsTUIEnabled() {
+		t.Error("expected SKILLSHARE_NO_TUI=TRUE (uppercase) to disable TUI")
+	}
+}
+
+func TestIsTUIEnabled_EnvWhitespace(t *testing.T) {
+	t.Setenv("SKILLSHARE_NO_TUI", "  true  ")
+	cfg := &Config{}
+	if cfg.IsTUIEnabled() {
+		t.Error("expected SKILLSHARE_NO_TUI with whitespace to disable TUI")
+	}
+}
+
+func TestIsTUIEnabled_EnvInvalidValue(t *testing.T) {
+	t.Setenv("SKILLSHARE_NO_TUI", "nope")
+	cfg := &Config{}
+	if !cfg.IsTUIEnabled() {
+		t.Error("expected invalid env value to fall through to config default")
+	}
+}
+
+func TestIsTUIEnabled_EnvEmptyString(t *testing.T) {
+	t.Setenv("SKILLSHARE_NO_TUI", "")
+	cfg := &Config{}
+	if !cfg.IsTUIEnabled() {
+		t.Error("expected empty env value to fall through to config default")
+	}
+}

--- a/website/docs/reference/appendix/environment-variables.md
+++ b/website/docs/reference/appendix/environment-variables.md
@@ -116,6 +116,18 @@ When both the env var and config file [`azure_hosts`](/docs/reference/targets/co
 
 ---
 
+### SKILLSHARE_NO_TUI
+
+Disable interactive TUI mode without modifying the config file. Set to `1`, `true`, or `yes` (case-insensitive).
+
+```bash
+SKILLSHARE_NO_TUI=1 skillshare list
+```
+
+**Default:** _(none — uses config file `tui` setting)_
+
+---
+
 ## Web UI
 
 ### SKILLSHARE_UI_BASE_PATH
@@ -379,6 +391,7 @@ export GITHUB_TOKEN="ghp_your_token_here"
 | `SKILLSHARE_UI_BASE_PATH` | Web UI sub-path for reverse proxy | None |
 | `SKILLSHARE_GITLAB_HOSTS` | Custom GitLab hostnames (comma-separated) | None |
 | `SKILLSHARE_AZURE_HOSTS` | Custom Azure DevOps Server hostnames (comma-separated) | None |
+| `SKILLSHARE_NO_TUI` | Disable interactive TUI mode (`1`, `true`, or `yes`) | None |
 | `XDG_CONFIG_HOME` | Base config directory | `~/.config` (Linux/macOS), `%AppData%` (Windows) |
 | `XDG_DATA_HOME` | Data directory (backups, trash) | `~/.local/share` |
 | `XDG_STATE_HOME` | State directory (logs) | `~/.local/state` |


### PR DESCRIPTION
## Summary

Implements #195.

Adds support for disabling TUI behavior through a process-local environment variable:

```bash
SKILLSHARE_NO_TUI=1 skillshare <command>
```

The env var accepts the following truthy values:

* `1`
* `true`
* `yes`

Values are trimmed and matched case-insensitively.

## Motivation

This is useful for CI/CD pipelines, scripts, devcontainers, and other non-interactive contexts where TUI behavior should be disabled without modifying the user's config file.

## Behavior

The effective priority is now:

```text
--no-tui flag > SKILLSHARE_NO_TUI env var > config tui field > default true
```

`SKILLSHARE_NO_TUI` only affects the current process. It does not modify the config file and does not change the behavior of `skillshare tui on/off`, which continue to read and write config directly.

## Changes

* Added `SKILLSHARE_NO_TUI` handling in config TUI resolution
* Added tests for:

  * unset env var preserving config behavior
  * `SKILLSHARE_NO_TUI=1`
  * `SKILLSHARE_NO_TUI=true`
  * `SKILLSHARE_NO_TUI=yes`
  * case-insensitive / whitespace-trimmed values
  * invalid values falling back to config
* Updated the TUI priority comment
* Documented the environment variable in the environment variables appendix

## Testing

Run inside Docker/devcontainer:

```bash
make test
make check
```

Closes #195
