### PR TITLE
fix(skillignore): memoize matchSegments to prevent exponential backtracking

### DIFF
--- a/internal/skillignore/globstar_test.go
+++ b/internal/skillignore/globstar_test.go
@@ -32,7 +32,7 @@ func TestRepeatedGlobstarDoesNotBacktrackExponentially(t *testing.T) {
 			t.Error("expected false: path has no segment '0'")
 		}
 	case <-time.After(5 * time.Second):
-		t.Fatal("Match with multiple ** segments hung — exponential backtracking regression")
+		t.Fatal("Match with multiple ** segments hung: exponential backtracking regression")
 	}
 }
 

--- a/internal/skillignore/globstar_test.go
+++ b/internal/skillignore/globstar_test.go
@@ -1,0 +1,167 @@
+package skillignore
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// RepeatedGlobstarDoesNotBacktrackExponentially ensures that patterns with
+// multiple consecutive ** segments complete in polynomial time.
+//
+// Repeated globstar patterns used to trigger exponential recursive
+// backtracking. This regression test uses a generous timeout only to
+// guard against the previous hang; it is not intended as a benchmark.
+func TestRepeatedGlobstarDoesNotBacktrackExponentially(t *testing.T) {
+	pattern := "**/**/**/**/0"
+	m := Compile([]string{pattern})
+
+	segs := make([]string, 150)
+	for i := range segs {
+		segs[i] = "1"
+	}
+	path := strings.Join(segs, "/")
+
+	ch := make(chan bool, 1)
+	go func() {
+		ch <- m.Match(path, false)
+	}()
+	select {
+	case matched := <-ch:
+		if matched {
+			t.Error("expected false: path has no segment '0'")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Match with multiple ** segments hung — exponential backtracking regression")
+	}
+}
+
+// TestGlobstarMatchingSemantics guards the core ** matching behavior
+// to ensure memoization did not alter results. Expected values are
+// derived from the current implementation, not from a gitignore spec.
+func TestGlobstarMatchingSemantics(t *testing.T) {
+	tests := []struct {
+		name     string
+		patterns []string
+		path     string
+		isDir    bool
+		want     bool
+	}{
+		{
+			name:     "single globstar matches zero segments",
+			patterns: []string{"**/foo"},
+			path:     "foo",
+			isDir:    false,
+			want:     true,
+		},
+		{
+			name:     "single globstar matches multiple segments",
+			patterns: []string{"**/foo"},
+			path:     "a/b/foo",
+			isDir:    false,
+			want:     true,
+		},
+		{
+			name:     "repeated globstar matches zero segments",
+			patterns: []string{"**/**/foo"},
+			path:     "foo",
+			isDir:    false,
+			want:     true,
+		},
+		{
+			name:     "repeated globstar matches nested path",
+			patterns: []string{"**/**/foo"},
+			path:     "a/b/foo",
+			isDir:    false,
+			want:     true,
+		},
+		{
+			name:     "triple globstar matches shallow path",
+			patterns: []string{"**/**/**/z"},
+			path:     "a/z",
+			isDir:    false,
+			want:     true,
+		},
+		{
+			name:     "triple globstar matches deep path",
+			patterns: []string{"**/**/**/z"},
+			path:     "a/b/z",
+			isDir:    false,
+			want:     true,
+		},
+		{
+			name:     "quad globstar matches deep path",
+			patterns: []string{"**/**/**/**/z"},
+			path:     "a/b/c/z",
+			isDir:    false,
+			want:     true,
+		},
+		{
+			name:     "repeated globstar returns false when suffix missing",
+			patterns: []string{"**/**/missing"},
+			path:     "a/b/foo",
+			isDir:    false,
+			want:     false,
+		},
+		{
+			name:     "anchored repeated globstar matches zero middle segments",
+			patterns: []string{"a/**/**/z"},
+			path:     "a/z",
+			isDir:    false,
+			want:     true,
+		},
+		{
+			name:     "anchored repeated globstar matches deep middle",
+			patterns: []string{"a/**/**/z"},
+			path:     "a/b/c/z",
+			isDir:    false,
+			want:     true,
+		},
+		{
+			name:     "anchored repeated globstar no match wrong prefix",
+			patterns: []string{"a/**/**/z"},
+			path:     "b/c/z",
+			isDir:    false,
+			want:     false,
+		},
+		{
+			name:     "quad globstar positive match",
+			patterns: []string{"**/**/**/**/0"},
+			path:     "1/2/3/4/0",
+			isDir:    false,
+			want:     true,
+		},
+		{
+			name:     "trailing repeated globstar",
+			patterns: []string{"foo/**/**"},
+			path:     "foo/a/b",
+			isDir:    false,
+			want:     true,
+		},
+		{
+			name:     "globstar matches directory isDir true",
+			patterns: []string{"**/foo"},
+			path:     "a/foo",
+			isDir:    true,
+			want:     true,
+		},
+		{
+			name:     "globstar no match directory isDir true",
+			patterns: []string{"**/missing"},
+			path:     "a/foo",
+			isDir:    true,
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := Compile(tt.patterns)
+			got := m.Match(tt.path, tt.isDir)
+			if got != tt.want {
+				t.Errorf("Compile(%q).Match(%q, %v) = %v, want %v",
+					tt.patterns, tt.path, tt.isDir, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/skillignore/skillignore.go
+++ b/internal/skillignore/skillignore.go
@@ -284,36 +284,49 @@ func matchRule(r rule, p string) bool {
 
 // matchSegments recursively matches pattern segments against path segments.
 // Handles ** (zero or more directories), and per-segment globs via path.Match.
+// Uses memoization to avoid exponential backtracking on multiple consecutive ** segments.
 func matchSegments(pat, p []string) bool {
-	pi, pp := 0, 0
-	for pi < len(pat) && pp < len(p) {
-		if pat[pi] == "**" {
-			// ** at end of pattern matches everything remaining
-			if pi == len(pat)-1 {
-				return true
-			}
-			// Try matching ** as zero or more segments
-			for skip := pp; skip <= len(p); skip++ {
-				if matchSegments(pat[pi+1:], p[skip:]) {
+	type key struct{ pi, pp int }
+	memo := make(map[key]bool)
+	var match func(pi, pp int) bool
+	match = func(pi, pp int) bool {
+		k := key{pi, pp}
+		if v, ok := memo[k]; ok {
+			return v
+		}
+		var result bool
+		defer func() { memo[k] = result }()
+
+		for pi < len(pat) && pp < len(p) {
+			if pat[pi] == "**" {
+				if pi == len(pat)-1 {
+					result = true
 					return true
 				}
+				for skip := pp; skip <= len(p); skip++ {
+					if match(pi+1, skip) {
+						result = true
+						return true
+					}
+				}
+				result = false
+				return false
 			}
-			return false
+			matched, _ := path.Match(pat[pi], p[pp])
+			if !matched {
+				result = false
+				return false
+			}
+			pi++
+			pp++
 		}
-		ok, _ := path.Match(pat[pi], p[pp])
-		if !ok {
-			return false
+		for pi < len(pat) && pat[pi] == "**" {
+			pi++
 		}
-		pi++
-		pp++
+		result = pi == len(pat) && pp == len(p)
+		return result
 	}
-
-	// Handle trailing ** in pattern
-	for pi < len(pat) && pat[pi] == "**" {
-		pi++
-	}
-
-	return pi == len(pat) && pp == len(p)
+	return match(0, 0)
 }
 
 // --- Deprecated API (backward compatibility) ---

--- a/internal/skillignore/skillignore.go
+++ b/internal/skillignore/skillignore.go
@@ -286,46 +286,73 @@ func matchRule(r rule, p string) bool {
 // Handles ** (zero or more directories), and per-segment globs via path.Match.
 // Uses memoization to avoid exponential backtracking on multiple consecutive ** segments.
 func matchSegments(pat, p []string) bool {
-	type key struct{ pi, pp int }
+	hasGlobstar := false
+	for _, seg := range pat {
+		if seg == "**" {
+			hasGlobstar = true
+			break
+		}
+	}
+
+	if !hasGlobstar {
+		if len(pat) != len(p) {
+			return false
+		}
+		for i := range pat {
+			matched, _ := path.Match(pat[i], p[i])
+			if !matched {
+				return false
+			}
+		}
+		return true
+	}
+
+	type key struct {
+		pi int
+		pp int
+	}
 	memo := make(map[key]bool)
+
 	var match func(pi, pp int) bool
 	match = func(pi, pp int) bool {
-		k := key{pi, pp}
+		k := key{pi: pi, pp: pp}
 		if v, ok := memo[k]; ok {
 			return v
 		}
-		var result bool
-		defer func() { memo[k] = result }()
 
 		for pi < len(pat) && pp < len(p) {
 			if pat[pi] == "**" {
 				if pi == len(pat)-1 {
-					result = true
+					memo[k] = true
 					return true
 				}
 				for skip := pp; skip <= len(p); skip++ {
 					if match(pi+1, skip) {
-						result = true
+						memo[k] = true
 						return true
 					}
 				}
-				result = false
+				memo[k] = false
 				return false
 			}
 			matched, _ := path.Match(pat[pi], p[pp])
 			if !matched {
-				result = false
+				memo[k] = false
 				return false
 			}
 			pi++
 			pp++
 		}
+
 		for pi < len(pat) && pat[pi] == "**" {
 			pi++
 		}
-		result = pi == len(pat) && pp == len(p)
-		return result
+
+		res := pi == len(pat) && pp == len(p)
+		memo[k] = res
+		return res
 	}
+
 	return match(0, 0)
 }
 


### PR DESCRIPTION

> Opened as a draft to confirm the fix direction before marking this ready for review.

## Summary

Fixes exponential backtracking in `internal/skillignore` globstar matching.

Repeated `**` segments caused recursive backtracking to revisit the same matching states many times. For example:

```text
**/**/**/**/0
```

matched against a long path like:

```text
1/1/1/1/.../1
```

could take a very long time or appear to hang.

This patch changes `matchSegments` to use index-based recursion with memoization by `(patternIndex, pathIndex)`, avoiding repeated evaluation of the same subproblems.

## Changes

* Memoize `matchSegments` states by `(patternIndex, pathIndex)`
* Add a regression test for repeated `**` patterns that previously caused backtracking blowup
* Add globstar semantics tests covering:

  * positive and negative repeated globstar cases
  * trailing repeated globstar
  * directory matching with `isDir=true`

## Behavior

The change is intended to preserve existing matching behavior while avoiding repeated evaluation of the same `(patternIndex, pathIndex)` states.

Existing tests pass, and the new globstar tests guard the core matching semantics around `**`.

## Testing

```bash
go test ./internal/skillignore -v
go test ./...
make test
make check
```

## Notes

Originally found via local fuzzing and minimized to a readable regression case.

Closes #198 
