### PR TITLE
fix: apply agent include/exclude filters in web UI sync

### DIFF
--- a/internal/server/handler_sync.go
+++ b/internal/server/handler_sync.go
@@ -192,12 +192,19 @@ func (s *Server) handleSync(w http.ResponseWriter, r *http.Request) {
 					continue
 				}
 
-				agentMode := target.AgentsConfig().Mode
+				ac := target.AgentsConfig()
+				agentMode := ac.Mode
 				if agentMode == "" {
 					agentMode = "merge"
 				}
 
-				agentResult, err := ssync.SyncAgents(agents, agentsSource, agentPath, agentMode, body.DryRun, body.Force)
+				filtered, filterErr := ssync.FilterAgents(agents, ac.Include, ac.Exclude)
+				if filterErr != nil {
+					warnings = append(warnings, "invalid agent filter for "+name+": "+filterErr.Error())
+					continue
+				}
+
+				agentResult, err := ssync.SyncAgents(filtered, agentsSource, agentPath, agentMode, body.DryRun, body.Force)
 				if err != nil {
 					warnings = append(warnings, "agent sync failed for "+name+": "+err.Error())
 					continue
@@ -207,9 +214,9 @@ func (s *Server) handleSync(w http.ResponseWriter, r *http.Request) {
 				// matches skills and clears previously synced target entries.
 				var pruned []string
 				if agentMode == "merge" {
-					pruned, _ = ssync.PruneOrphanAgentLinks(agentPath, agents, body.DryRun)
+					pruned, _ = ssync.PruneOrphanAgentLinks(agentPath, filtered, body.DryRun)
 				} else if agentMode == "copy" {
-					pruned, _ = ssync.PruneOrphanAgentCopies(agentPath, agents, body.DryRun)
+					pruned, _ = ssync.PruneOrphanAgentCopies(agentPath, filtered, body.DryRun)
 				}
 
 				// Find or create result entry for this target


### PR DESCRIPTION
Fixes #211

## Bug

The `handleSync` HTTP handler syncs all discovered agents to every configured target unconditionally. Any `agents.include` or `agents.exclude` filters set in `config.yaml` are silently ignored when syncing from the web UI, causing excluded agents to be written to targets they should be kept out of.

**Example config that should exclude an agent but doesn't (via UI):**
```yaml
targets:
  claude:
    agents:
      path: ~/.claude/agents
      exclude:
        - '*'
```

## Root cause

`sync_agents.go` (CLI path) correctly calls `FilterAgents` before syncing:
```go
filtered, filterErr := sync.FilterAgents(agents, ac.Include, ac.Exclude)
// ...
stats, targetErr := syncAgentTarget(..., filtered, ...)
```

`handler_sync.go` (UI path) was missing this call and passed the full `agents` slice directly to `SyncAgents` and `PruneOrphanAgentLinks/Copies`.

## Fix

Save `target.AgentsConfig()` to a local variable, call `ssync.FilterAgents` with its `Include`/`Exclude` fields, and pass the filtered slice to `SyncAgents` and both prune helpers. The prune calls also need the filtered list so that excluded agents are treated as orphans and removed from target directories on subsequent syncs.

No new imports — `ssync.FilterAgents` is already available via the existing `ssync` alias.