### PR TITLE
fix(git): sanitize push remote error output

### DIFF
--- a/internal/git/info.go
+++ b/internal/git/info.go
@@ -495,16 +495,21 @@ func PushRemoteWithAuth(dir string) error {
 }
 
 // PushRemoteWithEnv pushes to the default remote with additional environment
-// variables.
+// variables. Error output is sanitized of credential values via WrapGitError.
 func PushRemoteWithEnv(dir string, extraEnv []string) error {
 	cmd := exec.Command("git", "push")
 	cmd.Dir = dir
 	if len(extraEnv) > 0 {
 		cmd.Env = append(os.Environ(), extraEnv...)
 	}
-	out, err := cmd.CombinedOutput()
+
+	var outBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &outBuf
+
+	err := cmd.Run()
 	if err != nil {
-		return fmt.Errorf("git push failed: %s", strings.TrimSpace(string(out)))
+		return install.WrapGitError(outBuf.String(), err, install.UsedTokenAuth(extraEnv))
 	}
 	return nil
 }

--- a/internal/git/info_test.go
+++ b/internal/git/info_test.go
@@ -39,6 +39,53 @@ func initTestRepo(t *testing.T) string {
 	return dir
 }
 
+// TestPushRemoteWithEnv_TokenNotInError uses a fake git executable to verify
+// that PushRemoteWithEnv sanitizes credential-bearing content from git error
+// output. This does not assume every real git failure prints credentials; it
+// verifies that this wrapper does not return sensitive subprocess output
+// verbatim when such output is present.
+func TestPushRemoteWithEnv_TokenNotInError(t *testing.T) {
+	const token = "ghp_test_token_12345_redact"
+	const fakeGitErr = "fatal: unable to access 'https://x-access-token:" + token + "@github.com/org/repo.git/': Could not resolve host: github.com"
+
+	fakeBin := t.TempDir()
+	fakeGit := filepath.Join(fakeBin, "git")
+
+	script := "#!/bin/sh\n" +
+		"echo \"" + fakeGitErr + "\" >&2\n" +
+		"exit 128\n"
+
+	if err := os.WriteFile(fakeGit, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GITHUB_TOKEN", token)
+
+	extraEnv := []string{
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=url.https://x-access-token:" + token + "@github.com/.insteadOf",
+		"GIT_CONFIG_VALUE_0=https://github.com/",
+	}
+
+	err := PushRemoteWithEnv(t.TempDir(), extraEnv)
+	if err == nil {
+		t.Fatal("expected git push to fail")
+	}
+
+	msg := err.Error()
+
+	// Token must not appear in error output.
+	if strings.Contains(msg, token) {
+		t.Fatalf("token leaked in error: %v", err)
+	}
+
+	// Useful diagnostic text should survive sanitization.
+	if !strings.Contains(msg, "Could not resolve host") && !strings.Contains(msg, "unable to access") {
+		t.Fatalf("expected useful diagnostic in error, got: %v", err)
+	}
+}
+
 func TestIsRepo(t *testing.T) {
 	repo := initTestRepo(t)
 	if !IsRepo(repo) {


### PR DESCRIPTION
Fixes #214 

## Summary

This PR fixes `PushRemoteWithEnv` so failed `git push` output is routed through the existing `install.WrapGitError(...)` sanitizer instead of being returned raw.

The previous implementation used `cmd.CombinedOutput()` and returned the captured output directly via `fmt.Errorf(...)`. In token-auth flows, git subprocess output may contain credential-bearing URLs, so the wrapper should not return that output verbatim.

## Changes

* Replace raw `CombinedOutput()` error formatting in `PushRemoteWithEnv`.
* Capture stdout and stderr into one buffer to preserve the previous combined-output behavior.
* Route failed output through:

```go
install.WrapGitError(outBuf.String(), err, install.UsedTokenAuth(extraEnv))
```

* Add a regression test using a fake `git` executable and a fake token-bearing URL.

## Test notes

The regression test does not assume every real `git push` failure prints credentials. It verifies the wrapper's safety property: if subprocess error output contains credential-bearing content, `PushRemoteWithEnv` must not return it verbatim.

The test uses:

* fake token only;
* fake `git` executable;
* no real network access;
* no real GitHub token.

## Tests

* [x] `gofmt -w internal/git/info.go internal/git/info_test.go`
* [x] `go test ./internal/git/ -run TestPushRemoteWithEnv -v -count=1`
* [x] `go test ./internal/git/ ./internal/install/ -count=1`
* [x] `go vet ./internal/git/...`

## Scope

This PR only changes:

* `internal/git/info.go`
* `internal/git/info_test.go`

It does not touch `Commit`, source parsing, docs, proposals, or unrelated git helpers.
