### PR TITLE
fix: handle os.Remove and filepath.Rel errors in symlink conversion

### DIFF
--- a/internal/server/handler_targets.go
+++ b/internal/server/handler_targets.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -477,7 +478,9 @@ func (s *Server) unlinkMergeSymlinks(targetPath string) {
 		}
 
 		// Remove symlink and copy the skill back if source still exists
-		os.Remove(skillPath)
+		if err := os.Remove(skillPath); err != nil {
+			continue
+		}
 		if _, statErr := os.Stat(absLink); statErr == nil {
 			_ = copySkillDir(absLink, skillPath)
 		}
@@ -491,7 +494,10 @@ func copySkillDir(src, dst string) error {
 			return err
 		}
 
-		relPath, _ := filepath.Rel(src, path)
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return fmt.Errorf("failed to compute relative path from %s to %s: %w", src, path, err)
+		}
 		dstPath := filepath.Join(dst, relPath)
 
 		if info.IsDir() {


### PR DESCRIPTION
Two small fixes in `unlinkSymlinkMode` / `copySkillDir`:

1. **`os.Remove` error** — when removing a symlink fails, `continue` instead of proceeding to copy the skill back (which would follow the still-present symlink and overwrite the source).

2. **`filepath.Rel` error** — changed from silently ignored `_` to a returned error, preventing an empty `relPath` from causing the entire target directory to be overwritten.