### PR TITLE
Harden trash path boundary checks

### DIFF
--- a/internal/trash/trash.go
+++ b/internal/trash/trash.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"skillshare/internal/config"
@@ -15,6 +16,66 @@ import (
 const defaultMaxAge = 7 * 24 * time.Hour // 7 days
 
 const reservedAgentTrashDir = "agents"
+
+// validateTrashName rejects names that could cause path traversal when joined
+// with a base directory.  Allowed: plain names ("skill"), nested names
+// ("org/team-skill").  Rejected: empty, absolute, ".", "..", any segment
+// containing NUL, or any segment equal to "..".
+func validateTrashName(name string) error {
+	if name == "" {
+		return fmt.Errorf("trash name must not be empty")
+	}
+	if strings.ContainsRune(name, 0) {
+		return fmt.Errorf("trash name must not contain NUL")
+	}
+	if filepath.IsAbs(name) {
+		return fmt.Errorf("trash name must not be absolute: %s", name)
+	}
+	for _, part := range strings.Split(name, "/") {
+		if part == "" {
+			continue
+		}
+		if part == "." || part == ".." {
+			return fmt.Errorf("trash name must not contain path traversal segment %q in %q", part, name)
+		}
+	}
+	// Trash names use logical slash-separated paths.  Backslash is rejected
+	// even on Unix to unconditionally block Windows-style traversal syntax.
+	if strings.Contains(name, `\`) {
+		return fmt.Errorf("trash name must not contain backslash: %s", name)
+	}
+	return nil
+}
+
+// ensureUnderBase asserts that candidate resolves to a path under base.
+// Both are cleaned before comparison.  candidate == base is allowed (used by
+// RestoreAgent where targetDir may equal destDir).
+func ensureUnderBase(base, candidate string) error {
+	base = filepath.Clean(base)
+	candidate = filepath.Clean(candidate)
+	if candidate == base {
+		return nil
+	}
+	if !strings.HasPrefix(candidate, base+string(filepath.Separator)) {
+		return fmt.Errorf("path %q escapes base %q", candidate, base)
+	}
+	return nil
+}
+
+// ensureStrictlyUnderBase is like ensureUnderBase but rejects candidate == base.
+// Used by destructive sinks (e.g. Cleanup) that must never target the base
+// directory itself.
+func ensureStrictlyUnderBase(base, candidate string) error {
+	base = filepath.Clean(base)
+	candidate = filepath.Clean(candidate)
+	if candidate == base {
+		return fmt.Errorf("path %q equals base %q — refusing to operate on base", candidate, base)
+	}
+	if !strings.HasPrefix(candidate, base+string(filepath.Separator)) {
+		return fmt.Errorf("path %q escapes base %q", candidate, base)
+	}
+	return nil
+}
 
 // TrashDir returns the global trash directory path.
 func TrashDir() string {
@@ -38,8 +99,16 @@ func ProjectAgentTrashDir(root string) string {
 
 // MoveAgentToTrash moves an agent file (and its metadata) to the trash directory.
 func MoveAgentToTrash(agentFile, metaFile, name, trashBase string) (string, error) {
+	if err := validateTrashName(name); err != nil {
+		return "", fmt.Errorf("invalid trash name: %w", err)
+	}
+
 	timestamp := time.Now().Format("2006-01-02_15-04-05")
 	trashDir := filepath.Join(trashBase, name+"_"+timestamp)
+
+	if err := ensureUnderBase(trashBase, trashDir); err != nil {
+		return "", fmt.Errorf("trash path unsafe: %w", err)
+	}
 
 	if err := os.MkdirAll(trashDir, 0755); err != nil {
 		return "", fmt.Errorf("failed to create agent trash dir: %w", err)
@@ -87,9 +156,17 @@ type TrashEntry struct {
 // MoveToTrash moves a skill directory to the trash.
 // Uses os.Rename for atomic same-device moves, falls back to copy+delete.
 func MoveToTrash(srcPath, name, trashBase string) (string, error) {
+	if err := validateTrashName(name); err != nil {
+		return "", fmt.Errorf("invalid trash name: %w", err)
+	}
+
 	timestamp := time.Now().Format("2006-01-02_15-04-05")
 	trashName := name + "_" + timestamp
 	trashPath := filepath.Join(trashBase, trashName)
+
+	if err := ensureUnderBase(trashBase, trashPath); err != nil {
+		return "", fmt.Errorf("trash path unsafe: %w", err)
+	}
 
 	if err := os.MkdirAll(filepath.Dir(trashPath), 0755); err != nil {
 		return "", fmt.Errorf("failed to create trash directory: %w", err)
@@ -189,6 +266,9 @@ func Cleanup(trashBase string, maxAge time.Duration) (int, error) {
 
 	for _, item := range items {
 		if item.Date.Before(cutoff) {
+			if err := ensureStrictlyUnderBase(trashBase, item.Path); err != nil {
+				return removed, fmt.Errorf("skip unsafe item %s: %w", item.Name, err)
+			}
 			if err := os.RemoveAll(item.Path); err != nil {
 				return removed, fmt.Errorf("failed to clean up %s: %w", item.Name, err)
 			}
@@ -239,7 +319,15 @@ func FindByName(trashBase, name string) *TrashEntry {
 // Restore moves a trashed skill back to the destination directory.
 // Returns an error if the destination already exists.
 func Restore(entry *TrashEntry, destDir string) error {
+	if err := validateTrashName(entry.Name); err != nil {
+		return fmt.Errorf("invalid trash entry name: %w", err)
+	}
+
 	destPath := filepath.Join(destDir, entry.Name)
+
+	if err := ensureUnderBase(destDir, destPath); err != nil {
+		return fmt.Errorf("restore path unsafe: %w", err)
+	}
 
 	// Ensure parent directory exists for nested names (e.g., "org/_team-skills")
 	if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
@@ -271,11 +359,20 @@ func Restore(entry *TrashEntry, destDir string) error {
 // Unlike Restore (which moves the whole directory), this copies individual files
 // from the trashed directory to destDir (since agents are file-based, not directory-based).
 func RestoreAgent(entry *TrashEntry, destDir string) error {
+	if err := validateTrashName(entry.Name); err != nil {
+		return fmt.Errorf("invalid trash entry name: %w", err)
+	}
+
 	// Reconstruct subdirectory for nested agents (e.g., "demo/my-agent" → destDir/demo/)
 	targetDir := destDir
 	if subDir := filepath.Dir(entry.Name); subDir != "." {
 		targetDir = filepath.Join(destDir, subDir)
 	}
+
+	if err := ensureUnderBase(destDir, targetDir); err != nil {
+		return fmt.Errorf("restore path unsafe: %w", err)
+	}
+
 	if err := os.MkdirAll(targetDir, 0755); err != nil {
 		return fmt.Errorf("failed to create agent destination: %w", err)
 	}

--- a/internal/trash/trash_security_test.go
+++ b/internal/trash/trash_security_test.go
@@ -1,0 +1,599 @@
+package trash
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// --- Helpers ---
+
+// setupTraversalTree creates:
+//
+//	root/
+//	  base/     (trashBase)
+//	  outside/
+//	    canary.txt   (must never be touched)
+func setupTraversalTree(t *testing.T) (root, base, outside, canary string) {
+	t.Helper()
+	root = t.TempDir()
+	base = filepath.Join(root, "base")
+	outside = filepath.Join(root, "outside")
+	canary = filepath.Join(outside, "canary.txt")
+	os.MkdirAll(base, 0755)
+	os.MkdirAll(outside, 0755)
+	os.WriteFile(canary, []byte("canary"), 0644)
+	return
+}
+
+func assertCanaryUntouched(t *testing.T, canary string) {
+	t.Helper()
+	data, err := os.ReadFile(canary)
+	if err != nil {
+		t.Fatalf("canary file missing or unreadable: %v", err)
+	}
+	if string(data) != "canary" {
+		t.Errorf("canary was modified: got %q", string(data))
+	}
+}
+
+func assertNothingWrittenOutside(t *testing.T, root, base string) {
+	t.Helper()
+	baseClean := filepath.Clean(base)
+	filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		clean := filepath.Clean(path)
+		if clean == baseClean || strings.HasPrefix(clean, baseClean+string(filepath.Separator)) {
+			return nil
+		}
+		// Allow the root itself and the outside/ directory structure
+		rel, _ := filepath.Rel(root, clean)
+		if rel == "." || rel == "outside" || rel == "outside/canary.txt" {
+			return nil
+		}
+		if !info.IsDir() {
+			t.Errorf("unexpected file outside base: %s", path)
+		}
+		return nil
+	})
+}
+
+// --- Adversarial Tests: MoveToTrash ---
+
+func TestMoveToTrash_RejectsTraversal_DotDotSlash(t *testing.T) {
+	_, base, _, canary := setupTraversalTree(t)
+	srcDir := filepath.Join(base, "src")
+	os.MkdirAll(srcDir, 0755)
+	os.WriteFile(filepath.Join(srcDir, "SKILL.md"), []byte("content"), 0644)
+
+	_, err := MoveToTrash(srcDir, "../outside/pwn", base)
+	if err == nil {
+		t.Fatal("expected error for traversal name")
+	}
+
+	assertCanaryUntouched(t, canary)
+	assertNothingWrittenOutside(t, filepath.Dir(base), base)
+}
+
+func TestMoveToTrash_RejectsTraversal_DoubleDot(t *testing.T) {
+	_, base, _, canary := setupTraversalTree(t)
+	srcDir := filepath.Join(base, "src")
+	os.MkdirAll(srcDir, 0755)
+	os.WriteFile(filepath.Join(srcDir, "SKILL.md"), []byte("content"), 0644)
+
+	_, err := MoveToTrash(srcDir, "../../outside/pwn", base)
+	if err == nil {
+		t.Fatal("expected error for traversal name")
+	}
+
+	assertCanaryUntouched(t, canary)
+	assertNothingWrittenOutside(t, filepath.Dir(base), base)
+}
+
+func TestMoveToTrash_RejectsTraversal_Backslash(t *testing.T) {
+	_, base, _, canary := setupTraversalTree(t)
+	srcDir := filepath.Join(base, "src")
+	os.MkdirAll(srcDir, 0755)
+	os.WriteFile(filepath.Join(srcDir, "SKILL.md"), []byte("content"), 0644)
+
+	_, err := MoveToTrash(srcDir, `..\outside\pwn`, base)
+	if err == nil {
+		t.Fatal("expected error for backslash traversal name")
+	}
+
+	assertCanaryUntouched(t, canary)
+}
+
+func TestMoveToTrash_RejectsTraversal_AbsolutePath(t *testing.T) {
+	_, base, _, canary := setupTraversalTree(t)
+	srcDir := filepath.Join(base, "src")
+	os.MkdirAll(srcDir, 0755)
+	os.WriteFile(filepath.Join(srcDir, "SKILL.md"), []byte("content"), 0644)
+
+	_, err := MoveToTrash(srcDir, "/absolute/path", base)
+	if err == nil {
+		t.Fatal("expected error for absolute name")
+	}
+
+	assertCanaryUntouched(t, canary)
+}
+
+func TestMoveToTrash_RejectsTraversal_Empty(t *testing.T) {
+	_, base, _, _ := setupTraversalTree(t)
+
+	_, err := MoveToTrash(base, "", base)
+	if err == nil {
+		t.Fatal("expected error for empty name")
+	}
+}
+
+func TestMoveToTrash_RejectsTraversal_DotAlone(t *testing.T) {
+	_, base, _, _ := setupTraversalTree(t)
+
+	_, err := MoveToTrash(base, ".", base)
+	if err == nil {
+		t.Fatal("expected error for '.' name")
+	}
+}
+
+func TestMoveToTrash_RejectsTraversal_DotDotAlone(t *testing.T) {
+	_, base, _, _ := setupTraversalTree(t)
+
+	_, err := MoveToTrash(base, "..", base)
+	if err == nil {
+		t.Fatal("expected error for '..' name")
+	}
+}
+
+func TestMoveToTrash_RejectsTraversal_NulByte(t *testing.T) {
+	_, base, _, _ := setupTraversalTree(t)
+
+	_, err := MoveToTrash(base, "skill\x00/../../etc", base)
+	if err == nil {
+		t.Fatal("expected error for NUL byte in name")
+	}
+}
+
+func TestMoveToTrash_RejectsTraversal_EmbeddedDotDot(t *testing.T) {
+	_, base, _, canary := setupTraversalTree(t)
+	srcDir := filepath.Join(base, "src")
+	os.MkdirAll(srcDir, 0755)
+	os.WriteFile(filepath.Join(srcDir, "SKILL.md"), []byte("content"), 0644)
+
+	_, err := MoveToTrash(srcDir, "a/../../outside", base)
+	if err == nil {
+		t.Fatal("expected error for embedded traversal name")
+	}
+
+	assertCanaryUntouched(t, canary)
+	assertNothingWrittenOutside(t, filepath.Dir(base), base)
+}
+
+func TestEnsureStrictlyUnderBase_RejectsCandidateEqualsBase(t *testing.T) {
+	dir := t.TempDir()
+	err := ensureStrictlyUnderBase(dir, dir)
+	if err == nil {
+		t.Fatal("ensureStrictlyUnderBase must reject candidate == base")
+	}
+}
+
+func TestEnsureStrictlyUnderBase_RejectsEscape(t *testing.T) {
+	dir := t.TempDir()
+	err := ensureStrictlyUnderBase(dir, filepath.Join(dir, "..", "pwn"))
+	if err == nil {
+		t.Fatal("ensureStrictlyUnderBase must reject escape")
+	}
+}
+
+func TestEnsureStrictlyUnderBase_AllowsStrictSubpath(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "child")
+	if err := ensureStrictlyUnderBase(dir, sub); err != nil {
+		t.Fatalf("ensureStrictlyUnderBase should allow subpath: %v", err)
+	}
+}
+
+func TestMoveToTrash_AllowsNestedName(t *testing.T) {
+	_, base, _, _ := setupTraversalTree(t)
+	srcDir := filepath.Join(base, "src")
+	os.MkdirAll(filepath.Join(srcDir, "org", "team"), 0755)
+	os.WriteFile(filepath.Join(srcDir, "org", "team", "SKILL.md"), []byte("nested"), 0644)
+
+	trashPath, err := MoveToTrash(filepath.Join(srcDir, "org", "team"), "org/team-skill", base)
+	if err != nil {
+		t.Fatalf("nested name should be allowed: %v", err)
+	}
+
+	// Verify trashPath is under base
+	clean := filepath.Clean(trashPath)
+	baseClean := filepath.Clean(base)
+	if !strings.HasPrefix(clean, baseClean+string(filepath.Separator)) {
+		t.Errorf("trashPath %q escapes base %q", trashPath, base)
+	}
+
+	// Verify source was moved
+	if _, err := os.Stat(filepath.Join(srcDir, "org", "team")); !os.IsNotExist(err) {
+		t.Error("source should be removed after MoveToTrash")
+	}
+}
+
+// --- Adversarial Tests: MoveAgentToTrash ---
+
+func TestMoveAgentToTrash_RejectsTraversal_DotDotSlash(t *testing.T) {
+	_, base, _, canary := setupTraversalTree(t)
+
+	_, err := MoveAgentToTrash("dummy.md", "", "../outside/pwn", base)
+	if err == nil {
+		t.Fatal("expected error for traversal name")
+	}
+
+	assertCanaryUntouched(t, canary)
+}
+
+func TestMoveAgentToTrash_RejectsTraversal_Backslash(t *testing.T) {
+	_, base, _, canary := setupTraversalTree(t)
+
+	_, err := MoveAgentToTrash("dummy.md", "", `..\outside\pwn`, base)
+	if err == nil {
+		t.Fatal("expected error for backslash traversal name")
+	}
+
+	assertCanaryUntouched(t, canary)
+}
+
+func TestMoveAgentToTrash_RejectsTraversal_AbsolutePath(t *testing.T) {
+	_, base, _, canary := setupTraversalTree(t)
+
+	_, err := MoveAgentToTrash("dummy.md", "", "/absolute/path", base)
+	if err == nil {
+		t.Fatal("expected error for absolute name")
+	}
+
+	assertCanaryUntouched(t, canary)
+}
+
+func TestMoveAgentToTrash_AllowsNestedName(t *testing.T) {
+	_, base, outside, canary := setupTraversalTree(t)
+
+	// Create a valid agent file to exercise the full path
+	agentFile := filepath.Join(outside, "agent.md")
+	os.WriteFile(agentFile, []byte("payload"), 0644)
+
+	// "demo/my-agent" should be allowed
+	_, err := MoveAgentToTrash(agentFile, "", "demo/my-agent", base)
+	// It may error because agentFile isn't inside base for rename,
+	// but it must NOT create files outside base.
+	if err != nil {
+		t.Logf("MoveAgentToTrash returned error (expected for cross-device): %v", err)
+	}
+
+	assertCanaryUntouched(t, canary)
+	assertNothingWrittenOutside(t, filepath.Dir(base), base)
+}
+
+// --- Adversarial Tests: Restore ---
+
+func TestRestore_RejectsTraversal_DotDotSlash(t *testing.T) {
+	_, base, _, canary := setupTraversalTree(t)
+	destDir := filepath.Join(filepath.Dir(base), "dest")
+	os.MkdirAll(destDir, 0755)
+
+	entry := &TrashEntry{
+		Name:      "../../outside/pwn",
+		Path:      filepath.Join(base, "fake_2026-01-01_10-00-00"),
+		Timestamp: "2026-01-01_10-00-00",
+		Date:      time.Now(),
+	}
+
+	err := Restore(entry, destDir)
+	if err == nil {
+		t.Fatal("expected error for traversal entry name")
+	}
+
+	assertCanaryUntouched(t, canary)
+}
+
+func TestRestore_RejectsTraversal_Backslash(t *testing.T) {
+	_, base, _, canary := setupTraversalTree(t)
+	destDir := filepath.Join(filepath.Dir(base), "dest")
+	os.MkdirAll(destDir, 0755)
+
+	entry := &TrashEntry{
+		Name:      `..\outside\pwn`,
+		Path:      filepath.Join(base, "fake_2026-01-01_10-00-00"),
+		Timestamp: "2026-01-01_10-00-00",
+		Date:      time.Now(),
+	}
+
+	err := Restore(entry, destDir)
+	if err == nil {
+		t.Fatal("expected error for backslash traversal entry name")
+	}
+
+	assertCanaryUntouched(t, canary)
+}
+
+func TestRestore_RejectsTraversal_AbsolutePath(t *testing.T) {
+	_, base, _, canary := setupTraversalTree(t)
+	destDir := filepath.Join(filepath.Dir(base), "dest")
+	os.MkdirAll(destDir, 0755)
+
+	entry := &TrashEntry{
+		Name:      "/absolute/path",
+		Path:      filepath.Join(base, "fake_2026-01-01_10-00-00"),
+		Timestamp: "2026-01-01_10-00-00",
+		Date:      time.Now(),
+	}
+
+	err := Restore(entry, destDir)
+	if err == nil {
+		t.Fatal("expected error for absolute entry name")
+	}
+
+	assertCanaryUntouched(t, canary)
+}
+
+func TestRestore_AllowsNestedName(t *testing.T) {
+	_, base, _, _ := setupTraversalTree(t)
+	destDir := filepath.Join(filepath.Dir(base), "dest")
+	os.MkdirAll(destDir, 0755)
+
+	// Create a real trash entry
+	trashDir := filepath.Join(base, "org_skill_2026-01-01_10-00-00")
+	os.MkdirAll(trashDir, 0755)
+	os.WriteFile(filepath.Join(trashDir, "SKILL.md"), []byte("nested"), 0644)
+
+	entry := &TrashEntry{
+		Name:      "org/skill",
+		Path:      trashDir,
+		Timestamp: "2026-01-01_10-00-00",
+		Date:      time.Now(),
+	}
+
+	if err := Restore(entry, destDir); err != nil {
+		t.Fatalf("nested restore should succeed: %v", err)
+	}
+
+	// Verify restored file is under destDir
+	restored := filepath.Join(destDir, "org", "skill", "SKILL.md")
+	if _, err := os.Stat(restored); err != nil {
+		t.Errorf("restored file not found: %v", err)
+	}
+}
+
+// --- Adversarial Tests: RestoreAgent ---
+
+func TestRestoreAgent_RejectsTraversal_DotDotSlash(t *testing.T) {
+	_, base, _, canary := setupTraversalTree(t)
+	destDir := filepath.Join(filepath.Dir(base), "dest")
+	os.MkdirAll(destDir, 0755)
+
+	trashDir := filepath.Join(base, "agent_2026-01-01_10-00-00")
+	os.MkdirAll(trashDir, 0755)
+	os.WriteFile(filepath.Join(trashDir, "helper.md"), []byte("content"), 0644)
+
+	entry := &TrashEntry{
+		Name:      "../../outside/pwn",
+		Path:      trashDir,
+		Timestamp: "2026-01-01_10-00-00",
+		Date:      time.Now(),
+	}
+
+	err := RestoreAgent(entry, destDir)
+	if err == nil {
+		t.Fatal("expected error for traversal entry name")
+	}
+
+	assertCanaryUntouched(t, canary)
+}
+
+func TestRestoreAgent_RejectsTraversal_Backslash(t *testing.T) {
+	_, base, _, canary := setupTraversalTree(t)
+	destDir := filepath.Join(filepath.Dir(base), "dest")
+	os.MkdirAll(destDir, 0755)
+
+	trashDir := filepath.Join(base, "agent_2026-01-01_10-00-00")
+	os.MkdirAll(trashDir, 0755)
+	os.WriteFile(filepath.Join(trashDir, "helper.md"), []byte("content"), 0644)
+
+	entry := &TrashEntry{
+		Name:      `..\outside\pwn`,
+		Path:      trashDir,
+		Timestamp: "2026-01-01_10-00-00",
+		Date:      time.Now(),
+	}
+
+	err := RestoreAgent(entry, destDir)
+	if err == nil {
+		t.Fatal("expected error for backslash traversal entry name")
+	}
+
+	assertCanaryUntouched(t, canary)
+}
+
+func TestRestoreAgent_RejectsTraversal_AbsolutePath(t *testing.T) {
+	_, base, _, canary := setupTraversalTree(t)
+	destDir := filepath.Join(filepath.Dir(base), "dest")
+	os.MkdirAll(destDir, 0755)
+
+	entry := &TrashEntry{
+		Name:      "/absolute/path",
+		Path:      filepath.Join(base, "agent_2026-01-01_10-00-00"),
+		Timestamp: "2026-01-01_10-00-00",
+		Date:      time.Now(),
+	}
+
+	err := RestoreAgent(entry, destDir)
+	if err == nil {
+		t.Fatal("expected error for absolute entry name")
+	}
+
+	assertCanaryUntouched(t, canary)
+}
+
+func TestRestoreAgent_AllowsNestedName(t *testing.T) {
+	_, base, _, _ := setupTraversalTree(t)
+	destDir := filepath.Join(filepath.Dir(base), "dest")
+	os.MkdirAll(destDir, 0755)
+
+	trashDir := filepath.Join(base, "demo_agent_2026-01-01_10-00-00")
+	os.MkdirAll(trashDir, 0755)
+	os.WriteFile(filepath.Join(trashDir, "helper.md"), []byte("nested"), 0644)
+
+	entry := &TrashEntry{
+		Name:      "demo/my-agent",
+		Path:      trashDir,
+		Timestamp: "2026-01-01_10-00-00",
+		Date:      time.Now(),
+	}
+
+	if err := RestoreAgent(entry, destDir); err != nil {
+		t.Fatalf("nested agent restore should succeed: %v", err)
+	}
+
+	// RestoreAgent uses filepath.Dir(entry.Name) = "demo" as targetDir,
+	// then copies files from entry.Path into targetDir.
+	// So helper.md lands at destDir/demo/helper.md.
+	restored := filepath.Join(destDir, "demo", "helper.md")
+	if _, err := os.Stat(restored); err != nil {
+		t.Errorf("restored agent file not found: %v", err)
+	}
+}
+
+// --- Adversarial Tests: Cleanup ---
+
+func TestCleanup_PathTraversal(t *testing.T) {
+	root, base, _, canary := setupTraversalTree(t)
+
+	old := time.Now().Add(-8 * 24 * time.Hour).Format("2006-01-02_15-04-05")
+	os.MkdirAll(filepath.Join(base, "skill_"+old), 0755)
+	os.WriteFile(filepath.Join(base, "skill_"+old, "SKILL.md"), []byte("old"), 0644)
+
+	removed, err := Cleanup(base, 7*24*time.Hour)
+	if err != nil {
+		t.Fatalf("Cleanup error: %v", err)
+	}
+	if removed != 1 {
+		t.Errorf("expected 1 removed, got %d", removed)
+	}
+
+	assertCanaryUntouched(t, canary)
+	assertNothingWrittenOutside(t, root, base)
+}
+
+// --- Production Invariant Tests ---
+
+func TestList_EntryPathAlwaysUnderTrashBase(t *testing.T) {
+	_, base, _, _ := setupTraversalTree(t)
+
+	os.MkdirAll(filepath.Join(base, "skill-a_2026-01-01_10-00-00"), 0755)
+	os.MkdirAll(filepath.Join(base, "org", "repo_2026-01-02_10-00-00"), 0755)
+
+	items := List(base)
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+
+	for _, item := range items {
+		clean := filepath.Clean(item.Path)
+		baseClean := filepath.Clean(base)
+		if !strings.HasPrefix(clean, baseClean+string(filepath.Separator)) && clean != baseClean {
+			t.Errorf("item.Path %q escapes trash base %q", item.Path, base)
+		}
+	}
+}
+
+func TestList_NameNeverContainsDotDot(t *testing.T) {
+	_, base, _, _ := setupTraversalTree(t)
+
+	os.MkdirAll(filepath.Join(base, "skill_2026-01-01_10-00-00"), 0755)
+	os.MkdirAll(filepath.Join(base, "org", "repo_2026-01-02_10-00-00"), 0755)
+
+	items := List(base)
+	for _, item := range items {
+		if strings.Contains(item.Name, "..") {
+			t.Errorf("item.Name contains '..': %q", item.Name)
+		}
+	}
+}
+
+func TestList_NameJoinDestDirNeverEscapes(t *testing.T) {
+	_, base, _, _ := setupTraversalTree(t)
+	destDir := t.TempDir()
+
+	os.MkdirAll(filepath.Join(base, "skill_2026-01-01_10-00-00"), 0755)
+	os.MkdirAll(filepath.Join(base, "org", "repo_2026-01-02_10-00-00"), 0755)
+
+	items := List(base)
+	for _, item := range items {
+		destPath := filepath.Join(destDir, item.Name)
+		clean := filepath.Clean(destPath)
+		destClean := filepath.Clean(destDir)
+		if !strings.HasPrefix(clean, destClean+string(filepath.Separator)) && clean != destClean {
+			t.Errorf("Join(destDir, %q) = %q escapes destDir %q", item.Name, destPath, destDir)
+		}
+	}
+}
+
+func TestRestoreAgent_EntryNameFromListNeverEscapes(t *testing.T) {
+	_, base, _, _ := setupTraversalTree(t)
+	destDir := t.TempDir()
+
+	os.MkdirAll(filepath.Join(base, "skill_2026-01-01_10-00-00"), 0755)
+	os.MkdirAll(filepath.Join(base, "org", "repo_2026-01-02_10-00-00"), 0755)
+
+	items := List(base)
+	for _, item := range items {
+		subDir := filepath.Dir(item.Name)
+		targetDir := filepath.Join(destDir, subDir)
+		clean := filepath.Clean(targetDir)
+		destClean := filepath.Clean(destDir)
+		if !strings.HasPrefix(clean, destClean+string(filepath.Separator)) && clean != destClean {
+			t.Errorf("RestoreAgent targetDir %q escapes destDir %q for entry.Name %q",
+				targetDir, destDir, item.Name)
+		}
+	}
+}
+
+func TestFindByName_ResultPathUnderBase(t *testing.T) {
+	_, base, _, _ := setupTraversalTree(t)
+
+	os.MkdirAll(filepath.Join(base, "my-skill_2026-01-01_10-00-00"), 0755)
+
+	entry := FindByName(base, "my-skill")
+	if entry == nil {
+		t.Fatal("expected to find my-skill")
+	}
+
+	clean := filepath.Clean(entry.Path)
+	baseClean := filepath.Clean(base)
+	if !strings.HasPrefix(clean, baseClean+string(filepath.Separator)) && clean != baseClean {
+		t.Errorf("FindByName path %q escapes base %q", entry.Path, base)
+	}
+}
+
+func TestReadDir_NameNeverContainsSeparator(t *testing.T) {
+	_, base, _, _ := setupTraversalTree(t)
+
+	dir := filepath.Join(base, "entry_2026-01-01_10-00-00")
+	os.MkdirAll(dir, 0755)
+	os.WriteFile(filepath.Join(dir, "normal.md"), []byte("ok"), 0644)
+	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("ok"), 0644)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), "/") || strings.Contains(e.Name(), "\\") {
+			t.Errorf("ReadDir returned name with separator: %q", e.Name())
+		}
+		if strings.Contains(e.Name(), "..") {
+			t.Errorf("ReadDir returned name with '..': %q", e.Name())
+		}
+	}
+}


### PR DESCRIPTION
Fix #229 

## Summary

This PR hardens path boundary checks in `internal/trash`.

It addresses a function-level contract weakness found during G703 / CWE-22 path traversal triage: `MoveToTrash` previously accepted a caller-provided `name` that could contain traversal segments and influence the computed trash path.

This is treated as defense-in-depth hardening rather than a confirmed external exploit path. Current production callers appear to pass sanitized names, but the trash helpers perform filesystem write/move/delete/restore operations and should enforce their own invariants.

## Changes

* Add validation for trash-relative names.
* Reject traversal-style names, including:

  * `../outside`
  * `../../outside`
  * `a/../../outside`
  * backslash traversal
  * absolute paths
  * NUL-containing names
  * empty / `.` / `..`
* Preserve safe nested names such as:

  * `org/team-skill`
  * `demo/my-agent`
* Add under-base checks before filesystem operations.
* Add a stricter cleanup guard so cleanup cannot remove `trashBase` itself.
* Add regression tests in `internal/trash/trash_security_test.go`.

## Scope

Modified files:

* `internal/trash/trash.go`
* `internal/trash/trash_security_test.go`

No unrelated server, install, sync, config, or git behavior is changed.

## Security note

This PR does not claim a confirmed externally exploitable vulnerability. The issue was confirmed as a contract weakness: manually constructed malicious parameters could violate the intended path invariant, even though production callers currently appear to pass sanitized values.

The patch makes the invariant explicit inside the trash helpers.

## Validation

* `go test ./...` passes.
* `go vet ./...` passes.
* All added security regression tests pass.
* Existing trash behavior remains compatible with safe nested names.
