### PR TITLE
fix(uninstall): preserve dirty-repo guard in JSON mode

### DIFF
--- a/cmd/skillshare/uninstall.go
+++ b/cmd/skillshare/uninstall.go
@@ -584,11 +584,6 @@ func cmdUninstall(args []string) error {
 		return parseErr
 	}
 
-	// --json implies --force (skip confirmation prompts)
-	if opts.jsonOutput {
-		opts.force = true
-	}
-
 	cfg, err := config.Load()
 	if err != nil {
 		if opts.jsonOutput {
@@ -599,6 +594,7 @@ func cmdUninstall(args []string) error {
 
 	// Agent-only uninstall: move .md + sidecar to agent trash, then return.
 	if kind == kindAgents {
+		opts.force = opts.force || opts.jsonOutput
 		agentsDir := cfg.EffectiveAgentsSource()
 		err := cmdUninstallAgents(agentsDir, opts, config.ConfigPath(), trash.AgentTrashDir(), start)
 		return err
@@ -841,11 +837,17 @@ func cmdUninstall(args []string) error {
 			// Repo is dirty
 			if !opts.force {
 				if single {
+					dirtyErr := fmt.Errorf("uncommitted changes detected, use --force to override")
+					if opts.jsonOutput {
+						return writeJSONError(dirtyErr)
+					}
 					ui.Error("Repository has uncommitted changes!")
 					ui.Info("Use --force to uninstall anyway, or commit/stash your changes first")
-					return fmt.Errorf("uncommitted changes detected, use --force to override")
+					return dirtyErr
 				}
-				ui.StepSkip(t.name, "uncommitted changes, use --force")
+				if !opts.jsonOutput {
+					ui.StepSkip(t.name, "uncommitted changes, use --force")
+				}
 				continue
 			}
 			if !opts.jsonOutput {
@@ -893,7 +895,7 @@ func cmdUninstall(args []string) error {
 		return nil
 	}
 
-	if !opts.force {
+	if !opts.force && !opts.jsonOutput {
 		if single {
 			confirmed, err := confirmUninstall(targets[0])
 			if err != nil {
@@ -1178,7 +1180,7 @@ Options:
   --group, -G <name>  Remove all skills in a group (prefix match, repeatable)
   --force, -f         Skip confirmation and ignore uncommitted changes
   --dry-run, -n       Preview without making changes
-  --json              Output results as JSON (implies --force)
+  --json              Global mode: output JSON and skip confirmation
   --project, -p       Use project-level config in current directory
   --global, -g        Use global config (~/.config/skillshare)
   --help, -h          Show this help

--- a/cmd/skillshare/uninstall.go
+++ b/cmd/skillshare/uninstall.go
@@ -866,6 +866,9 @@ func cmdUninstall(args []string) error {
 
 		if len(targets) == 0 {
 			preflightErr := fmt.Errorf("no skills to uninstall after pre-flight checks")
+			if preflightSkipped > 0 {
+				preflightErr = fmt.Errorf("%d tracked repo%s skipped due to uncommitted changes; use --force to override", preflightSkipped, pluralS(preflightSkipped))
+			}
 			if opts.jsonOutput {
 				return writeJSONError(preflightErr)
 			}

--- a/skills/skillshare/SKILL.md
+++ b/skills/skillshare/SKILL.md
@@ -170,7 +170,7 @@ skillshare sync --json                         # Sync results as JSON
 skillshare diff --json                         # Diff results as JSON
 skillshare install user/repo --json            # Install result as JSON (implies --force --all)
 skillshare update --all --json                 # Update results as JSON
-skillshare uninstall my-skill --json           # Uninstall result as JSON (implies --force)
+skillshare uninstall my-skill --json           # Global JSON; dirty tracked repos still require --force
 skillshare collect claude --json               # Collect result as JSON (implies --force)
 skillshare target list --json                  # Target list as JSON
 skillshare list --json                         # Skill list as JSON

--- a/skills/skillshare/references/install.md
+++ b/skills/skillshare/references/install.md
@@ -176,7 +176,7 @@ skillshare uninstall -G frontend -p --force
 # Preview
 skillshare uninstall --group frontend --dry-run
 
-# JSON output (implies --force)
+# Global JSON output (skips confirmation; dirty tracked repos still require --force)
 skillshare uninstall my-skill --json
 ```
 

--- a/tests/integration/json_output_test.go
+++ b/tests/integration/json_output_test.go
@@ -727,6 +727,23 @@ func TestUninstall_JSON_DirtyRepoRequiresExplicitForce(t *testing.T) {
 		t.Fatal("dirty tracked repo should remain without explicit --force")
 	}
 
+	// An all-dirty batch should explain why pre-flight rejected every target.
+	secondRepoPath := sb.SourcePath + "/_uninst-preflight-2"
+	run(t, sb.Root, "git", "clone", remoteDir, secondRepoPath)
+	sb.WriteFile(secondRepoPath+"/dirty.txt", "uncommitted")
+
+	result = sb.RunCLI("uninstall", "uninst-preflight", "uninst-preflight-2", "--json")
+	result.AssertFailure(t)
+	assertPureJSON(t, strings.TrimSpace(result.Stdout))
+	output = parseJSON(t, result.Stdout)
+	errorMessage, _ := output["error"].(string)
+	if !strings.Contains(errorMessage, "uncommitted changes") {
+		t.Fatalf("expected actionable dirty-repo error, got %q", errorMessage)
+	}
+	if !sb.FileExists(repoPath) || !sb.FileExists(secondRepoPath) {
+		t.Fatal("all dirty tracked repos should remain without explicit --force")
+	}
+
 	// Batch JSON output should stay pure while skipping only the dirty repo.
 	sb.CreateSkill("clean-skill", map[string]string{"SKILL.md": "# Clean"})
 	result = sb.RunCLI("uninstall", "uninst-preflight", "clean-skill", "--json")

--- a/tests/integration/json_output_test.go
+++ b/tests/integration/json_output_test.go
@@ -148,14 +148,14 @@ func TestUninstall_JSON_DryRun(t *testing.T) {
 	}
 }
 
-func TestUninstall_JSON_ImpliesForce(t *testing.T) {
+func TestUninstall_JSON_SkipsConfirmation(t *testing.T) {
 	sb := testutil.NewSandbox(t)
 	defer sb.Cleanup()
 
 	sb.CreateSkill("auto-force", map[string]string{"SKILL.md": "# Auto"})
 	sb.WriteConfig(`source: ` + sb.SourcePath + "\ntargets: {}\n")
 
-	// --json should skip confirmation (implies --force)
+	// --json should skip confirmation without requiring --force.
 	result := sb.RunCLI("uninstall", "auto-force", "--json")
 	result.AssertSuccess(t)
 
@@ -695,7 +695,7 @@ func TestUninstall_JSON_AllEmpty_ReturnsJSONError(t *testing.T) {
 	}
 }
 
-func TestUninstall_JSON_PreflightEmpty_ReturnsJSONError(t *testing.T) {
+func TestUninstall_JSON_DirtyRepoRequiresExplicitForce(t *testing.T) {
 	sb := testutil.NewSandbox(t)
 	defer sb.Cleanup()
 
@@ -715,12 +715,40 @@ func TestUninstall_JSON_PreflightEmpty_ReturnsJSONError(t *testing.T) {
 	// Add uncommitted change
 	sb.WriteFile(repoPath+"/dirty.txt", "uncommitted")
 
-	// --json implies --force, so this should actually succeed.
-	// But if the skill is the only target and preflight skips it, we should get JSON error.
-	// Actually --json implies --force which bypasses preflight. Let's test without --force override.
-	// Note: --json already implies --force in current code, so we can't test preflight block via --json.
-	// Skip this test — it's not actually testable with --json implying --force.
-	t.Skip("--json implies --force, cannot test preflight block in JSON mode")
+	result := sb.RunCLI("uninstall", "uninst-preflight", "--json")
+	result.AssertFailure(t)
+	assertPureJSON(t, strings.TrimSpace(result.Stdout))
+
+	output := parseJSON(t, result.Stdout)
+	if _, ok := output["error"]; !ok {
+		t.Error("expected 'error' field in JSON output")
+	}
+	if !sb.FileExists(repoPath) {
+		t.Fatal("dirty tracked repo should remain without explicit --force")
+	}
+
+	// Batch JSON output should stay pure while skipping only the dirty repo.
+	sb.CreateSkill("clean-skill", map[string]string{"SKILL.md": "# Clean"})
+	result = sb.RunCLI("uninstall", "uninst-preflight", "clean-skill", "--json")
+	result.AssertSuccess(t)
+	assertPureJSON(t, strings.TrimSpace(result.Stdout))
+	output = parseJSON(t, result.Stdout)
+	if output["skipped"] != float64(1) {
+		t.Fatalf("expected one skipped dirty repo, got %v", output["skipped"])
+	}
+	if !sb.FileExists(repoPath) {
+		t.Fatal("batch uninstall should preserve the dirty tracked repo")
+	}
+	if sb.FileExists(filepath.Join(sb.SourcePath, "clean-skill")) {
+		t.Fatal("batch uninstall should remove the clean skill")
+	}
+
+	result = sb.RunCLI("uninstall", "uninst-preflight", "--json", "--force")
+	result.AssertSuccess(t)
+	assertPureJSON(t, strings.TrimSpace(result.Stdout))
+	if sb.FileExists(repoPath) {
+		t.Fatal("dirty tracked repo should be removed with explicit --force")
+	}
 }
 
 // --- status --project --json ---

--- a/website/docs/reference/commands/uninstall.md
+++ b/website/docs/reference/commands/uninstall.md
@@ -44,7 +44,7 @@ flowchart TD
 | `--dry-run, -n` | Preview without making changes |
 | `--project, -p` | Use project-level config in current directory |
 | `--global, -g` | Use global config (`~/.config/skillshare`) |
-| `--json` | Output as JSON (implies `--force`, skips confirmation) |
+| `--json` | Global mode: output JSON and skip confirmation; dirty tracked repositories still require `--force` |
 | `--help, -h` | Show help |
 
 ## JSON Output


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] Small improvement (docs, typo, minor refactor)
- [ ] Feature proposal (`proposals/` only — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Linked Issue

Closes #242

## What changed

Global skill `uninstall --json` no longer sets `force=true` internally. JSON mode remains non-interactive, but a dirty tracked repository now requires an explicit `--force`.

The regression coverage checks four paths:

- a clean skill is removed without a confirmation prompt;
- a dirty tracked repository returns a pure JSON error and remains in place;
- an all-dirty batch reports the uncommitted changes instead of a generic pre-flight error;
- mixed batches skip dirty repositories without polluting JSON output, while `--json --force` retains the previous forced behavior.

The CLI help, command reference, and bundled Skillshare skill now describe the updated boundary. This PR does not change project skill uninstall, agent uninstall, `install`, or `collect` JSON semantics.

## Validation

- `make check`
- `SKILLSHARE_TEST_BINARY=/tmp/skillshare-pr-bin go test -v ./tests/integration -run 'TestUninstall_JSON_(SkipsConfirmation|DirtyRepoRequiresExplicitForce)' -count=1`

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Tests included and passing (`make check`) — for code changes
- [x] No unrelated changes in the diff
- [x] Scope is focused — one concern per PR
