### PR TITLE
fix(project): refuse to re-init a project that lost its config.yaml

### DIFF
--- a/cmd/skillshare/diff_agents.go
+++ b/cmd/skillshare/diff_agents.go
@@ -14,10 +14,8 @@ import (
 
 // diffProjectAgents computes agent diffs for project mode.
 func diffProjectAgents(root, targetName string, opts diffRenderOpts, start time.Time) error {
-	if !projectConfigExists(root) {
-		if err := performProjectInit(root, projectInitOptions{}); err != nil {
-			return err
-		}
+	if err := ensureProjectConfig(root); err != nil {
+		return err
 	}
 
 	rt, err := loadProjectRuntime(root)

--- a/cmd/skillshare/diff_project.go
+++ b/cmd/skillshare/diff_project.go
@@ -14,10 +14,8 @@ func cmdDiffProject(root, targetName string, kind resourceKindFilter, opts diffR
 	if kind == kindAgents {
 		return diffProjectAgents(root, targetName, opts, start)
 	}
-	if !projectConfigExists(root) {
-		if err := performProjectInit(root, projectInitOptions{}); err != nil {
-			return err
-		}
+	if err := ensureProjectConfig(root); err != nil {
+		return err
 	}
 
 	runtime, err := loadProjectRuntime(root)

--- a/cmd/skillshare/install_project.go
+++ b/cmd/skillshare/install_project.go
@@ -31,10 +31,8 @@ func cmdInstallProjectParsed(parsed *installArgs, root string) (installLogSummar
 	summary.Into = parsed.opts.Into
 	summary.SkipAudit = parsed.opts.SkipAudit
 
-	if !projectConfigExists(root) {
-		if err := performProjectInit(root, projectInitOptions{}); err != nil {
-			return summary, err
-		}
+	if err := ensureProjectConfig(root); err != nil {
+		return summary, err
 	}
 
 	runtime, err := loadProjectRuntime(root)

--- a/cmd/skillshare/list_project.go
+++ b/cmd/skillshare/list_project.go
@@ -11,10 +11,8 @@ import (
 )
 
 func cmdListProject(root string, opts listOptions, kind resourceKindFilter) error {
-	if !projectConfigExists(root) {
-		if err := performProjectInit(root, projectInitOptions{}); err != nil {
-			return err
-		}
+	if err := ensureProjectConfig(root); err != nil {
+		return err
 	}
 
 	projCfg, err := config.LoadProject(root)

--- a/cmd/skillshare/mode.go
+++ b/cmd/skillshare/mode.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"skillshare/internal/ui"
 )
@@ -58,4 +59,50 @@ func modeString(mode runMode) string {
 func projectConfigExists(root string) bool {
 	_, err := os.Stat(filepath.Join(root, ".skillshare", "config.yaml"))
 	return err == nil
+}
+
+// ensureProjectConfig initializes a project when that is safe, and reports the
+// case where initializing would discard an existing project instead.
+//
+// Auto-init is intentional in two situations and both are preserved: a
+// repository with no .skillshare/ at all, and the shared skills repo produced
+// by 'init -p --config local', which gitignores config.yaml so every developer
+// regenerates their own.
+//
+// The case in between used to be silent. A .skillshare/ that already holds
+// skills or agents, whose config.yaml is simply gone, was re-initialized into
+// an empty config — dropping every configured target, leaving stale target
+// links, and exiting 0.
+func ensureProjectConfig(root string) error {
+	if projectConfigExists(root) {
+		return nil
+	}
+	dir := filepath.Join(root, ".skillshare")
+	if info, err := os.Stat(dir); err == nil && info.IsDir() {
+		gitignored, err := isConfigGitignored(root)
+		if (err != nil || !gitignored) && projectDirHasContent(dir) {
+			return fmt.Errorf(
+				".skillshare/ in %s holds skills or agents but has no config.yaml\n"+
+					"Restore it from version control, or run 'skillshare init -p' to write a new one",
+				root)
+		}
+	}
+	return performProjectInit(root, projectInitOptions{})
+}
+
+// projectDirHasContent reports whether .skillshare/ holds authored skills or
+// agents that a regenerated config would no longer describe.
+func projectDirHasContent(dir string) bool {
+	for _, name := range []string{"skills", "agents"} {
+		entries, err := os.ReadDir(filepath.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if !strings.HasPrefix(entry.Name(), ".") {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/cmd/skillshare/require_project_config_test.go
+++ b/cmd/skillshare/require_project_config_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeSkill(t *testing.T, dir, name string) {
+	t.Helper()
+	skillDir := filepath.Join(dir, name)
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	body := "---\nname: " + name + "\ndescription: Fixture skill.\n---\n\n# " + name + "\n"
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnsureProjectConfig_AlreadyInitialized(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, ".skillshare")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("targets: []\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureProjectConfig(root); err != nil {
+		t.Errorf("ensureProjectConfig() = %v, want nil", err)
+	}
+}
+
+// A repository with no project directory at all still bootstraps, which is the
+// documented behaviour of the project commands.
+func TestEnsureProjectConfig_NoProjectStillInitializes(t *testing.T) {
+	root := t.TempDir()
+
+	if err := ensureProjectConfig(root); err != nil {
+		t.Fatalf("ensureProjectConfig() = %v, want nil", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".skillshare", "config.yaml")); err != nil {
+		t.Errorf("no config created for a fresh repository: %v", err)
+	}
+}
+
+// The --config local shared skills repo gitignores config.yaml, so a fresh
+// clone legitimately has content but no config and must still regenerate one.
+func TestEnsureProjectConfig_SharedRepoStillRepairs(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, ".skillshare")
+	writeSkill(t, filepath.Join(dir, "skills"), "shared-skill")
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("config.yaml\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureProjectConfig(root); err != nil {
+		t.Fatalf("ensureProjectConfig() = %v, want nil for the shared-repo flow", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "config.yaml")); err != nil {
+		t.Errorf("shared-repo repair did not write a config: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "skills", "shared-skill", "SKILL.md")); err != nil {
+		t.Errorf("shared skill was disturbed: %v", err)
+	}
+}
+
+// The guarded case: a project directory that already holds content, whose
+// config.yaml is simply missing and is not gitignored. Re-initializing would
+// replace it with an empty config and silently drop every configured target.
+func TestEnsureProjectConfig_RefusesToDiscardExistingProject(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, ".skillshare")
+	writeSkill(t, filepath.Join(dir, "skills"), "demo")
+
+	err := ensureProjectConfig(root)
+	if err == nil {
+		t.Fatal("ensureProjectConfig() = nil, want an error for a content-bearing project without a config")
+	}
+	if !strings.Contains(err.Error(), ".skillshare") {
+		t.Errorf("error %q does not name the project directory", err)
+	}
+	if !strings.Contains(err.Error(), "init -p") {
+		t.Errorf("error %q does not point at 'init -p'", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "config.yaml")); !os.IsNotExist(statErr) {
+		t.Error("a config was written over an existing project")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "skills", "demo", "SKILL.md")); statErr != nil {
+		t.Errorf("existing skill was disturbed: %v", statErr)
+	}
+}
+
+// Agents alone are enough to make a project worth protecting.
+func TestEnsureProjectConfig_RefusesWhenOnlyAgentsExist(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, ".skillshare")
+	writeSkill(t, filepath.Join(dir, "agents"), "demo-agent")
+
+	if err := ensureProjectConfig(root); err == nil {
+		t.Fatal("ensureProjectConfig() = nil, want an error for a project holding only agents")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "config.yaml")); !os.IsNotExist(err) {
+		t.Error("a config was written over an existing project")
+	}
+}
+
+// An empty project directory has nothing to lose, so it repairs silently as
+// before.
+func TestEnsureProjectConfig_EmptyProjectDirRepairs(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, ".skillshare")
+	if err := os.MkdirAll(filepath.Join(dir, "skills"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureProjectConfig(root); err != nil {
+		t.Fatalf("ensureProjectConfig() = %v, want nil for an empty project directory", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "config.yaml")); err != nil {
+		t.Errorf("empty project directory was not repaired: %v", err)
+	}
+}
+
+// Regression guard for the reported data loss, at the command level.
+func TestCmdStatusProject_DoesNotDiscardExistingProject(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, ".skillshare")
+	writeSkill(t, filepath.Join(dir, "skills"), "demo")
+
+	if err := cmdStatusProject(root); err == nil {
+		t.Fatal("cmdStatusProject() = nil, want an error for a content-bearing project without a config")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "config.yaml")); !os.IsNotExist(err) {
+		t.Error("status wrote a fresh config over an existing project")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "skills", "demo", "SKILL.md")); err != nil {
+		t.Errorf("existing skill was disturbed: %v", err)
+	}
+}

--- a/cmd/skillshare/search.go
+++ b/cmd/skillshare/search.go
@@ -441,11 +441,8 @@ func installFromSearchResultProject(result search.SearchResult, cwd string) (err
 		logInstallOp(config.ProjectConfigPath(cwd), []string{result.Source}, start, err, logSummary)
 	}()
 
-	// Auto-init project if not yet initialized
-	if !projectConfigExists(cwd) {
-		if err := performProjectInit(cwd, projectInitOptions{}); err != nil {
-			return err
-		}
+	if err := ensureProjectConfig(cwd); err != nil {
+		return err
 	}
 
 	runtime, err := loadProjectRuntime(cwd)

--- a/cmd/skillshare/search_batch.go
+++ b/cmd/skillshare/search_batch.go
@@ -381,13 +381,10 @@ func collectSearchInstallProject(result search.SearchResult, cwd string, onProgr
 		source: result.Source,
 	}
 
-	// Auto-init project if not yet initialized
-	if !projectConfigExists(cwd) {
-		if err := performProjectInit(cwd, projectInitOptions{}); err != nil {
-			r.status = "failed"
-			r.detail = fmt.Sprintf("project init: %v", err)
-			return r
-		}
+	if err := ensureProjectConfig(cwd); err != nil {
+		r.status = "failed"
+		r.detail = fmt.Sprintf("project config: %v", err)
+		return r
 	}
 
 	runtime, err := loadProjectRuntime(cwd)
@@ -588,13 +585,11 @@ func batchInstallFromSearchWithProgress(selected []search.SearchResult, mode run
 }
 
 // resolveBatchSourceDir returns the skill source directory for the given mode.
-// For project mode, it also ensures project config is initialized.
+// For project mode, it requires an initialized project config.
 func resolveBatchSourceDir(mode runMode, cfg *config.Config, cwd string) (string, error) {
 	if mode == modeProject {
-		if !projectConfigExists(cwd) {
-			if err := performProjectInit(cwd, projectInitOptions{}); err != nil {
-				return "", fmt.Errorf("project init: %w", err)
-			}
+		if err := ensureProjectConfig(cwd); err != nil {
+			return "", fmt.Errorf("project config: %w", err)
 		}
 		runtime, err := loadProjectRuntime(cwd)
 		if err != nil {

--- a/cmd/skillshare/status_project.go
+++ b/cmd/skillshare/status_project.go
@@ -16,10 +16,8 @@ import (
 )
 
 func cmdStatusProject(root string) error {
-	if !projectConfigExists(root) {
-		if err := performProjectInit(root, projectInitOptions{}); err != nil {
-			return err
-		}
+	if err := ensureProjectConfig(root); err != nil {
+		return err
 	}
 
 	runtime, err := loadProjectRuntime(root)
@@ -55,10 +53,8 @@ func cmdStatusProject(root string) error {
 }
 
 func cmdStatusProjectJSON(root string) error {
-	if !projectConfigExists(root) {
-		if err := performProjectInit(root, projectInitOptions{}); err != nil {
-			return writeJSONError(err)
-		}
+	if err := ensureProjectConfig(root); err != nil {
+		return writeJSONError(err)
 	}
 
 	runtime, err := loadProjectRuntime(root)

--- a/cmd/skillshare/sync_project.go
+++ b/cmd/skillshare/sync_project.go
@@ -20,10 +20,8 @@ func cmdSyncProject(root string, dryRun, force, jsonOutput, quiet bool) (syncLog
 		ProjectScope: true,
 	}
 
-	if !projectConfigExists(root) {
-		if err := performProjectInit(root, projectInitOptions{}); err != nil {
-			return stats, nil, nil, nil, err
-		}
+	if err := ensureProjectConfig(root); err != nil {
+		return stats, nil, nil, nil, err
 	}
 
 	runtime, err := loadProjectRuntime(root)

--- a/cmd/skillshare/target_project.go
+++ b/cmd/skillshare/target_project.go
@@ -31,10 +31,8 @@ func targetAddProject(args []string, root string) error {
 		return fmt.Errorf("invalid target name: %w", err)
 	}
 
-	if !projectConfigExists(root) {
-		if err := performProjectInit(root, projectInitOptions{}); err != nil {
-			return err
-		}
+	if err := ensureProjectConfig(root); err != nil {
+		return err
 	}
 
 	knownPath := ""
@@ -128,10 +126,8 @@ func targetRemoveProject(args []string, root string) error {
 		return err
 	}
 
-	if !projectConfigExists(root) {
-		if err := performProjectInit(root, projectInitOptions{}); err != nil {
-			return err
-		}
+	if err := ensureProjectConfig(root); err != nil {
+		return err
 	}
 
 	cfg, err := config.LoadProject(root)
@@ -259,10 +255,8 @@ func targetListProject(root string) error {
 }
 
 func targetListProjectWithJSON(root string, jsonOutput bool) error {
-	if !projectConfigExists(root) {
-		if err := performProjectInit(root, projectInitOptions{}); err != nil {
-			return err
-		}
+	if err := ensureProjectConfig(root); err != nil {
+		return err
 	}
 
 	if jsonOutput {
@@ -293,10 +287,8 @@ func targetListProjectWithJSON(root string, jsonOutput bool) error {
 }
 
 func targetInfoProject(name string, args []string, root string) error {
-	if !projectConfigExists(root) {
-		if err := performProjectInit(root, projectInitOptions{}); err != nil {
-			return err
-		}
+	if err := ensureProjectConfig(root); err != nil {
+		return err
 	}
 
 	// Parse filter flags first, pass remaining to mode parsing

--- a/cmd/skillshare/uninstall_project.go
+++ b/cmd/skillshare/uninstall_project.go
@@ -80,10 +80,8 @@ func cmdUninstallProject(args []string, root string) error {
 		return err
 	}
 
-	if !projectConfigExists(root) {
-		if err := performProjectInit(root, projectInitOptions{}); err != nil {
-			return err
-		}
+	if err := ensureProjectConfig(root); err != nil {
+		return err
 	}
 
 	projectCfg, loadErr := config.LoadProject(root)

--- a/cmd/skillshare/update_agents.go
+++ b/cmd/skillshare/update_agents.go
@@ -735,10 +735,8 @@ func cmdUpdateAgentsProject(args []string, projectRoot string, start time.Time) 
 		return err
 	}
 
-	if !projectConfigExists(projectRoot) {
-		if err := performProjectInit(projectRoot, projectInitOptions{}); err != nil {
-			return failJSON(err)
-		}
+	if err := ensureProjectConfig(projectRoot); err != nil {
+		return failJSON(err)
 	}
 
 	runtime, err := loadProjectRuntime(projectRoot)

--- a/cmd/skillshare/update_project.go
+++ b/cmd/skillshare/update_project.go
@@ -26,10 +26,8 @@ func cmdUpdateProject(args []string, root string) (*updateResult, error) {
 		opts.all = true
 	}
 
-	if !projectConfigExists(root) {
-		if err := performProjectInit(root, projectInitOptions{}); err != nil {
-			return nil, err
-		}
+	if err := ensureProjectConfig(root); err != nil {
+		return nil, err
 	}
 
 	runtime, err := loadProjectRuntime(root)


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] Small improvement (docs, typo, minor refactor)
- [ ] Feature proposal (`proposals/` only — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Linked Issue

Split out of #258 at your request — this is the missing-config guard on its own, with none of the visible-directory changes. #258 will be rebased on top of this so the feature can be reviewed separately.

## Problem

Every project-mode command auto-initializes when `.skillshare/config.yaml` is missing. That is right for a repository with no project directory at all, and for the shared skills repo produced by `init -p --config local`, which gitignores `config.yaml` so each developer regenerates their own.

It was wrong for the case in between. A `.skillshare/` that already held skills or agents, whose `config.yaml` was simply gone, was re-initialized into an empty config: every configured target dropped, target symlinks left behind pointing at a project the config no longer described, exit code 0, nothing reported.

## Approach

A new `ensureProjectConfig` helper in `cmd/skillshare/mode.go` replaces the open-coded `if !projectConfigExists { performProjectInit }` pattern at every project entry point (17 call sites across 13 files — the same sites #258 touched, minus everything visible-directory related).

It initializes exactly as before when there is no project directory, and when `config.yaml` is covered by `.skillshare/.gitignore` — so both intentional auto-init cases are unchanged. When the directory holds skills or agents and its config is neither present nor gitignored, it returns an error pointing at version control or an explicit `skillshare init -p` instead of writing over the project.

Two deliberate details:

- The gitignore check is treated as inconclusive on error, so a repository that cannot be inspected is guarded rather than overwritten.
- Dotfile-only entries under `skills/` or `agents/` do not count as content, so an effectively-empty directory still repairs silently.

## Test coverage

`cmd/skillshare/require_project_config_test.go` covers the guard in all four states — initialized project, no project directory (still bootstraps), gitignored-config shared repo (still repairs, content untouched), and a content-bearing project without a config (errors, writes nothing) — plus agents-only content, an empty project directory, and a command-level regression test that `status -p` refuses rather than overwriting.

`gofmt`, `go vet ./...` and `go build ./...` are clean. `go test ./...` shows no failures beyond the two that already fail on unmodified `main` in my environment (`TestCommitSourceFiles_CommitFailureIsReturned` and `TestGitRootMismatch`, both host-git-config dependent — same two noted in #258).

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Tests included and passing — for code changes
- [x] No unrelated changes in the diff
- [x] Scope is focused — one concern per PR
