### PR TITLE
fix(update): resolve dot-dir subdirs in batch update before stale classification

### DIFF
--- a/internal/install/batch_update.go
+++ b/internal/install/batch_update.go
@@ -2,8 +2,12 @@ package install
 
 import (
 	"fmt"
+	"os"
+	"path"
 	"path/filepath"
 	"strings"
+
+	"skillshare/internal/utils"
 )
 
 // BatchUpdateProgressPrefix marks per-skill grouped update progress messages
@@ -71,6 +75,13 @@ func UpdateSkillsFromRepo(repoURL string, skillTargets map[string]string, opts I
 		}
 		skillInfo, ok := discoveryMap[lookupKey]
 		if !ok {
+			// Discovery skips target dot-dirs (.claude, .codex, ...), so a skill
+			// installed from such a subdir never appears in the map even though it
+			// still exists upstream. Resolve the subdir directly before declaring
+			// the path deleted, otherwise the skill is misreported as stale.
+			skillInfo, ok = lookupSkillSubdir(repoPath, lookupKey)
+		}
+		if !ok {
 			result.Errors[repoSubdir] = fmt.Errorf("skill path %q not found in repository", repoSubdir)
 			processedSkills++
 			emitBatchSkillProgress(opts.OnProgress, processedSkills, totalSkills, repoSubdir)
@@ -107,6 +118,31 @@ func UpdateSkillsFromRepo(repoURL string, skillTargets map[string]string, opts I
 	}
 
 	return result, nil
+}
+
+// lookupSkillSubdir resolves a skill subdir that discovery filtered out by
+// checking the cloned repo directly for its SKILL.md. Mirrors the direct-stat
+// fast path used by single-skill updates (resolveSubdir).
+func lookupSkillSubdir(repoPath, subdir string) (SkillInfo, bool) {
+	if repoPath == "" || subdir == "" || subdir == "." {
+		return SkillInfo{}, false
+	}
+	cleaned := path.Clean(strings.ReplaceAll(subdir, "\\", "/"))
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") || path.IsAbs(cleaned) {
+		return SkillInfo{}, false
+	}
+	skillFile := filepath.Join(repoPath, filepath.FromSlash(cleaned), "SKILL.md")
+	info, err := os.Stat(skillFile)
+	if err != nil || info.IsDir() {
+		return SkillInfo{}, false
+	}
+	fm := utils.ParseFrontmatterFields(skillFile, []string{"description", "license"})
+	return SkillInfo{
+		Name:        path.Base(cleaned),
+		Path:        cleaned,
+		License:     fm["license"],
+		Description: fm["description"],
+	}, true
 }
 
 // isSkillCurrentAtRepoState returns true when installed metadata already

--- a/internal/install/batch_update_test.go
+++ b/internal/install/batch_update_test.go
@@ -219,3 +219,82 @@ func TestRefreshSkillMetaVersionIfNeeded(t *testing.T) {
 		t.Fatalf("expected tree hash to be preserved, got %q", updated.TreeHash)
 	}
 }
+
+func TestLookupSkillSubdir(t *testing.T) {
+	repo := t.TempDir()
+	skillDir := filepath.Join(repo, ".claude", "skills", "my-skill")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := "---\nname: my-skill\ndescription: does things\nlicense: MIT\n---\n# my-skill"
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	info, ok := lookupSkillSubdir(repo, ".claude/skills/my-skill")
+	if !ok {
+		t.Fatal("expected skill under target dot-dir to be resolved")
+	}
+	if info.Name != "my-skill" {
+		t.Errorf("expected name %q, got %q", "my-skill", info.Name)
+	}
+	if info.Path != ".claude/skills/my-skill" {
+		t.Errorf("expected path %q, got %q", ".claude/skills/my-skill", info.Path)
+	}
+	if info.Description != "does things" {
+		t.Errorf("expected description from frontmatter, got %q", info.Description)
+	}
+	if info.License != "MIT" {
+		t.Errorf("expected license from frontmatter, got %q", info.License)
+	}
+
+	if _, ok := lookupSkillSubdir(repo, ".claude/skills/deleted-skill"); ok {
+		t.Error("expected missing subdir to not resolve")
+	}
+	if _, ok := lookupSkillSubdir(repo, ".claude/skills"); ok {
+		t.Error("expected dir without SKILL.md to not resolve")
+	}
+	for _, subdir := range []string{"", ".", "..", "../outside", "/abs/path"} {
+		if _, ok := lookupSkillSubdir(repo, subdir); ok {
+			t.Errorf("expected subdir %q to be rejected", subdir)
+		}
+	}
+}
+
+func TestUpdateSkillsFromRepo_SkillOnlyInTargetDotDirNotStale(t *testing.T) {
+	origDirs := TargetDotDirs
+	TargetDotDirs = map[string]bool{".claude": true, ".cursor": true, ".skillshare": true}
+	defer func() { TargetDotDirs = origDirs }()
+
+	repo := initTestRepo(t)
+	skillDir := filepath.Join(repo, ".claude", "skills", "my-skill")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: my-skill\n---\n# my-skill"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Force-add: user-level global gitignores commonly exclude .claude/.
+	runGit(t, repo, "add", "-f", ".")
+	gitCommit(t, repo, "add skill inside target dot-dir")
+
+	sourceDir := t.TempDir()
+	dest := filepath.Join(sourceDir, "my-skill")
+
+	result, err := UpdateSkillsFromRepo("file://"+repo,
+		map[string]string{".claude/skills/my-skill": dest},
+		InstallOptions{Update: true, SkipAudit: true, SourceDir: sourceDir})
+	if err != nil {
+		t.Fatalf("UpdateSkillsFromRepo failed: %v", err)
+	}
+
+	if updateErr, exists := result.Errors[".claude/skills/my-skill"]; exists {
+		t.Fatalf("expected no error for skill inside target dot-dir, got: %v", updateErr)
+	}
+	if _, exists := result.Results[".claude/skills/my-skill"]; !exists {
+		t.Fatal("expected install result for skill inside target dot-dir")
+	}
+	if _, err := os.Stat(filepath.Join(dest, "SKILL.md")); err != nil {
+		t.Fatalf("expected SKILL.md installed at destination: %v", err)
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing! Please read CONTRIBUTING.md before submitting. -->

## Type

- [x] Bug fix
- [ ] Small improvement (docs, typo, minor refactor)
- [ ] Feature proposal (`proposals/` only — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Linked Issue

Closes #261

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Tests included and passing (`make check`) — for code changes
- [x] No unrelated changes in the diff
- [x] Scope is focused — one concern per PR

## Summary

`update --all` falsely reports a skill as `stale (deleted upstream)` when the upstream repo ships the skill only inside a target dot-dir (`.claude/`, `.codex/`, `.github/`, ...). Batch update looks up `meta.Subdir` in the discovery map, but discovery deliberately skips `TargetDotDirs`, so the lookup can never succeed for such skills — and `--prune` would then trash a healthy install. Full analysis in #261.

## Fix

On a discovery-map miss, `UpdateSkillsFromRepo` now falls back to `lookupSkillSubdir`, a direct `SKILL.md` stat of the subdir in the cloned repo (mirroring the `resolveSubdir` fast path that makes single-skill `update <name>` succeed for the same skill). Only a genuinely absent path is still reported as `skill path %q not found in repository` and classified stale. The fallback rejects `..`/absolute subdirs and requires `SKILL.md` to exist, and fills `SkillInfo` license/description from frontmatter like regular discovery does.

## Tests

- `TestLookupSkillSubdir` — resolves a skill under `.claude/skills/`, rejects missing dirs, dirs without `SKILL.md`, and traversal/absolute inputs.
- `TestUpdateSkillsFromRepo_SkillOnlyInTargetDotDirNotStale` — end-to-end batch update from a `file://` repo whose only skill lives in `.claude/skills/`; asserts no error and the skill installs. Fails on `main` with the stale misclassification, passes with the fix.

Note: the existing dot-dir e2e coverage (`ai_docs/tests/discovery_skip_target_dotdirs_runbook.md`) only exercises repos that also carry skills outside the dot-dirs, so this case was previously untested.
