### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ If you find skillshare useful, consider giving it a ⭐
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=runkids/skillshare&type=date&legend=top-left)](https://www.star-history.com/#runkids/skillshare&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=runkids/skillshare&type=date&legend=top-left)](https://star-history.dera.page/#runkids/skillshare&type=date&legend=top-left)
 
 ---
 


### PR DESCRIPTION
The star history chart in the README is currently broken and no longer renders, so visitors miss the project's popularity at a glance. This points the chart and its link at a working mirror of the same service, restoring the graph without any change in layout or parameters.