### PR TITLE
fix(skillignore): strip \r so CRLF files match

### DIFF
--- a/internal/skillignore/skillignore.go
+++ b/internal/skillignore/skillignore.go
@@ -32,7 +32,7 @@ type Matcher struct {
 // Returns the rule and true if valid, or zero value and false if the line
 // should be skipped (blank or comment).
 func parseRule(line string) (rule, bool) {
-	line = strings.TrimRight(line, " \t")
+	line = strings.TrimRight(line, " \t\r")
 
 	// Blank line
 	if line == "" {
@@ -94,7 +94,7 @@ func parseRule(line string) (rule, bool) {
 func Compile(lines []string) *Matcher {
 	m := &Matcher{}
 	for _, line := range lines {
-		trimmed := strings.TrimRight(line, " \t")
+		trimmed := strings.TrimRight(line, " \t\r")
 		r, ok := parseRule(line)
 		if !ok {
 			continue

--- a/internal/skillignore/skillignore_test.go
+++ b/internal/skillignore/skillignore_test.go
@@ -3,6 +3,7 @@ package skillignore
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -762,5 +763,61 @@ func TestNormalizePath(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("normalizePath(%q) = %q, want %q", tt.input, got, tt.want)
 		}
+	}
+}
+
+// --- CRLF line endings ---
+
+// Files saved on Windows (or checked out with core.autocrlf=true) carry a
+// trailing \r on every line. It must be stripped like other trailing
+// whitespace, otherwise no pattern in the file can ever match.
+func TestCompile_CRLF(t *testing.T) {
+	m := Compile([]string{"*.log\r", "build/\r", "!error.log\r", "# comment\r", "\r"})
+	if len(m.rules) != 3 {
+		t.Fatalf("expected 3 rules, got %d", len(m.rules))
+	}
+	if !m.Match("debug.log", false) {
+		t.Error("*.log should match debug.log")
+	}
+	if m.Match("error.log", false) {
+		t.Error("!error.log negation should still apply")
+	}
+	if !m.Match("build", true) {
+		t.Error("build/ should match the build dir")
+	}
+	for _, p := range m.Patterns() {
+		if strings.ContainsRune(p, '\r') {
+			t.Errorf("Patterns() should not carry \\r: %q", p)
+		}
+	}
+}
+
+func TestReadMatcher_CRLF(t *testing.T) {
+	dir := t.TempDir()
+	content := "# comment\r\n_team/foo\r\nexperimental-*\r\n"
+	os.WriteFile(filepath.Join(dir, ".skillignore"), []byte(content), 0644)
+
+	m := ReadMatcher(dir)
+	if !m.HasRules() {
+		t.Fatal("expected rules")
+	}
+	if !m.Match("_team/foo", false) {
+		t.Error("_team/foo should be ignored")
+	}
+	if !m.Match("experimental-x", false) {
+		t.Error("experimental-* should match experimental-x")
+	}
+	if m.Match("_team/bar", false) {
+		t.Error("_team/bar should not be ignored")
+	}
+}
+
+func TestReadMatcher_CRLFWithTrailingSpace(t *testing.T) {
+	dir := t.TempDir()
+	// A \r after trailing spaces used to shield those spaces from trimming.
+	os.WriteFile(filepath.Join(dir, ".skillignore"), []byte("_team/foo  \r\n"), 0644)
+
+	if !ReadMatcher(dir).Match("_team/foo", false) {
+		t.Error("trailing spaces before \\r should be trimmed")
 	}
 }

--- a/internal/skillignore/write.go
+++ b/internal/skillignore/write.go
@@ -19,7 +19,7 @@ func AddPattern(filePath, pattern string) (bool, error) {
 
 	// Check for duplicate in a single pass
 	for _, line := range strings.Split(content, "\n") {
-		if strings.TrimRight(line, " \t") == pattern {
+		if strings.TrimRight(line, " \t\r") == pattern {
 			return false, nil
 		}
 	}
@@ -47,7 +47,7 @@ func RemovePattern(filePath, pattern string) (bool, error) {
 	var kept []string
 	found := false
 	for _, line := range lines {
-		trimmed := strings.TrimRight(line, " \t")
+		trimmed := strings.TrimRight(line, " \t\r")
 		if trimmed == pattern {
 			found = true
 			continue
@@ -75,7 +75,7 @@ func HasPattern(filePath, pattern string) bool {
 	}
 
 	for _, line := range strings.Split(string(data), "\n") {
-		if strings.TrimRight(line, " \t") == pattern {
+		if strings.TrimRight(line, " \t\r") == pattern {
 			return true
 		}
 	}

--- a/internal/skillignore/write_test.go
+++ b/internal/skillignore/write_test.go
@@ -185,3 +185,49 @@ func TestHasPattern_MissingFile(t *testing.T) {
 		t.Error("expected false for missing file")
 	}
 }
+
+// --- CRLF line endings ---
+
+func TestHasPattern_CRLF(t *testing.T) {
+	dir := t.TempDir()
+	fp := filepath.Join(dir, ".skillignore")
+	os.WriteFile(fp, []byte("my-skill\r\nother\r\n"), 0644)
+
+	if !HasPattern(fp, "my-skill") {
+		t.Error("HasPattern should find a pattern in a CRLF file")
+	}
+}
+
+func TestAddPattern_CRLFDoesNotDuplicate(t *testing.T) {
+	dir := t.TempDir()
+	fp := filepath.Join(dir, ".skillignore")
+	os.WriteFile(fp, []byte("my-skill\r\n"), 0644)
+
+	added, err := AddPattern(fp, "my-skill")
+	if err != nil {
+		t.Fatalf("AddPattern: %v", err)
+	}
+	if added {
+		t.Error("pattern already present in a CRLF file should not be added again")
+	}
+}
+
+func TestRemovePattern_CRLF(t *testing.T) {
+	dir := t.TempDir()
+	fp := filepath.Join(dir, ".skillignore")
+	os.WriteFile(fp, []byte("keep\r\nmy-skill\r\n"), 0644)
+
+	removed, err := RemovePattern(fp, "my-skill")
+	if err != nil {
+		t.Fatalf("RemovePattern: %v", err)
+	}
+	if !removed {
+		t.Fatal("pattern in a CRLF file should be found and removed")
+	}
+	if HasPattern(fp, "my-skill") {
+		t.Error("pattern should be gone")
+	}
+	if !HasPattern(fp, "keep") {
+		t.Error("other patterns must be kept")
+	}
+}


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] Small improvement (docs, typo, minor refactor)
- [ ] Feature proposal (`proposals/` only — see [CONTRIBUTING.md](../CONTRIBUTING.md))

## Linked Issue

Closes #275

## Summary

`ReadMatcher` splits on `"\n"` and `parseRule` / `Compile` only trimmed `" \t"`, so a `.skillignore` saved with CRLF line endings compiled every rule with a trailing `\r` that can never equal a path segment. `status` still reported the patterns as loaded, so the file silently ignored nothing. The same trim in `write.go` made `HasPattern` miss existing entries, `AddPattern` duplicate them and `RemovePattern` fail to find them (`disable` / `enable` against a CRLF file).

This regressed in 4214cb10 (v0.17.4); the pre-Matcher `ReadPatterns` used `TrimSpace` and handled CRLF.

Fix: trim `\r` alongside the existing whitespace in all five places, matching how git reads a CRLF `.gitignore`.

Tests: six new cases — `Compile` with CRLF lines (negation, comment and blank line included), `ReadMatcher` with and without trailing spaces before the `\r`, and `HasPattern` / `AddPattern` / `RemovePattern` on CRLF files. All six fail without the change.

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Tests included and passing (`make check`) — for code changes
- [x] No unrelated changes in the diff
- [x] Scope is focused — one concern per PR
